### PR TITLE
Fix logout button functionality

### DIFF
--- a/SensorApp/SensorApp.Maui/ViewModels/LogoutViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/LogoutViewModel.cs
@@ -5,17 +5,16 @@ namespace SensorApp.Maui.ViewModels;
 
 public partial class LogoutViewModel : BaseViewModel
 {
-    public LogoutViewModel()
-    {
-        Logout();
-    }
-
-
     [RelayCommand]
-    async void Logout()
+    public async Task LogoutAsync()
     {
         SecureStorage.Remove("Token");
         App.UserInfo = null;
-        await Shell.Current.GoToAsync($"{nameof(LoginPage)}");
+
+        Application.Current.MainPage = new AppShell();
+
+        await Task.Delay(100);
+
+        await Shell.Current.GoToAsync(nameof(LoginPage));
     }
 }

--- a/SensorApp/SensorApp.Maui/Views/Pages/LogoutPage.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/LogoutPage.cs
@@ -2,19 +2,23 @@
 
 namespace SensorApp.Maui.Views.Pages;
 
-public class LogoutPage : ContentPage
+public partial class LogoutPage : ContentPage
 {
+    private readonly LogoutViewModel _logoutViewModel;
+
     public LogoutPage(LogoutViewModel logoutViewModel)
     {
-        Content = new VerticalStackLayout
-        {
-            Children = {
-                new Label { HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center, Text = "Logging Out"
-                }
-            }
-        };
+
+
+        _logoutViewModel = logoutViewModel;
 
         BindingContext = logoutViewModel;
 
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _logoutViewModel.LogoutAsync();
     }
 }


### PR DESCRIPTION
This PR fixes an issue where logging out would sometimes fail and leave the user stuck on the "Logging Out" screen. The root cause was that the app attempted to navigate to the `LoginPage `too early (before the shell was initialize) which resulted in a `NullReferenceException`. 
To resolve this, the logout flow was moved to the `OnAppearing `method of `LogoutPage`, and the entire `AppShell `is reset with a slight delay to allow `Shell `to initialize before navigating to the login screen. 

