### PR TITLE
Allow viewing, creation, resolving and deletion of sensor incidents

### DIFF
--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -72,5 +72,20 @@ public static class IncidentEndpoints
             await db.SaveChangesAsync();
             return Results.Ok();
         });
+
+        routes.MapPut("/incident/resolve/{id}", async (int id, IncidentResolutionDto resolutionDto, SensorDbContext db) =>
+        {
+            var incident = await db.Incidents.FindAsync(id);
+            if (incident == null)
+                return Results.NotFound();
+
+            incident.Status = "Resolved";
+            incident.Resolution_date = DateTime.UtcNow;
+            incident.Comments = resolutionDto.ResolutionComments;
+
+            await db.SaveChangesAsync();
+            return Results.Ok();
+        });
+
     }
 }

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -4,7 +4,8 @@ using SensorApp.Database.Data;
 using SensorApp.Shared.Dtos.Admin;
 using SensorApp.Shared.Dtos;
 using SensorApp.Shared.Dtos.Incident;
-using SensorApp.Shared.Enums;
+using SensorApp.Database.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace SensorApp.Api.Endpoints;
 
@@ -47,6 +48,29 @@ public static class IncidentEndpoints
             return Results.Ok(incidents);
 
         });
-        //.RequireAuthorization(policy => policy.RequireRole(UserRole.OperationsManager.ToString()));
+
+        routes.MapPost("/incident/create", async (
+            HttpContext context,
+            SensorDbContext db,
+            CreateIncidentDto dto,
+            UserManager<IdentityUser> userManager) =>
+        {
+                var currentUserId = userManager.GetUserId(context.User);
+
+                var incident = new Incident
+            {
+                Type = dto.Type,
+                Status = dto.Status,
+                Sensor_id = dto.SensorId,
+                Creation_date = DateTime.UtcNow,
+                Priority = dto.Priority,
+                Comments = dto.Comments,
+                Responder_id = currentUserId
+                };
+
+            db.Incidents.Add(incident);
+            await db.SaveChangesAsync();
+            return Results.Ok();
+        });
     }
 }

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -87,5 +87,15 @@ public static class IncidentEndpoints
             return Results.Ok();
         });
 
+        routes.MapDelete("/incident/delete/{id}", async (int id, SensorDbContext db) =>
+        {
+            var incident = await db.Incidents.FindAsync(id);
+            if (incident == null)
+                return Results.NotFound();
+
+            db.Incidents.Remove(incident);
+            await db.SaveChangesAsync();
+            return Results.Ok();
+        });
     }
 }

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SensorApp.Database.Data;
+using SensorApp.Shared.Dtos.Admin;
+using SensorApp.Shared.Dtos;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Enums;
+
+namespace SensorApp.Api.Endpoints;
+
+public static class IncidentEndpoints
+{
+    public static void MapIncidentEndpoints(this IEndpointRouteBuilder routes)
+    {
+        //GET all existing users
+        routes.MapGet("/incidents", async (SensorDbContext db, UserManager<IdentityUser> userManager) =>
+        {
+            var incidents = await db.Incidents
+                .Select(i => new IncidentDto
+                {
+                    Id = i.Id,
+                    Type = i.Type,
+                    Status = i.Status,
+                    Sensor = new SensorDto
+                    {
+                        Id = i.Sensor.Id,
+                        Type = i.Sensor.Type,
+                        Latitude = i.Sensor.Latitude,
+                        Longitude = i.Sensor.Longitude,
+                        Site_zone = i.Sensor.Site_zone,
+                        Status = i.Sensor.Status
+                    },
+                    Sensor_id = i.Sensor_id,
+                    Creation_date = i.Creation_date,
+                    Priority = i.Priority,
+                    Resolution_date = i.Resolution_date,
+                    Responder_id = i.Responder_id,
+                    Responder = new UserWithRoleDto
+                    {
+                        Id = i.Responder.Id,
+                        Username = i.Responder.UserName,
+                    },
+                    Comments = i.Comments
+                })
+                .ToListAsync();
+
+            return Results.Ok(incidents);
+
+        });
+        //.RequireAuthorization(policy => policy.RequireRole(UserRole.OperationsManager.ToString()));
+    }
+}

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
-using SensorApp.Database.Data;
-using SensorApp.Shared.Dtos.Admin;
-using SensorApp.Shared.Dtos;
 using SensorApp.Shared.Dtos.Incident;
-using SensorApp.Database.Models;
-using Microsoft.AspNetCore.Http;
+using SensorApp.Api.Services.Interfaces;
 
 namespace SensorApp.Api.Endpoints;
 
@@ -13,89 +8,39 @@ public static class IncidentEndpoints
 {
     public static void MapIncidentEndpoints(this IEndpointRouteBuilder routes)
     {
-        //GET all existing users
-        routes.MapGet("/incidents", async (SensorDbContext db, UserManager<IdentityUser> userManager) =>
+        routes.MapGet("/incidents", async (IIncidentService service) =>
         {
-            var incidents = await db.Incidents
-                .Select(i => new IncidentDto
-                {
-                    Id = i.Id,
-                    Type = i.Type,
-                    Status = i.Status,
-                    Sensor = new SensorDto
-                    {
-                        Id = i.Sensor.Id,
-                        Type = i.Sensor.Type,
-                        Latitude = i.Sensor.Latitude,
-                        Longitude = i.Sensor.Longitude,
-                        Site_zone = i.Sensor.Site_zone,
-                        Status = i.Sensor.Status
-                    },
-                    Sensor_id = i.Sensor_id,
-                    Creation_date = i.Creation_date,
-                    Priority = i.Priority,
-                    Resolution_date = i.Resolution_date,
-                    Responder_id = i.Responder_id,
-                    Responder = new UserWithRoleDto
-                    {
-                        Id = i.Responder.Id,
-                        Username = i.Responder.UserName,
-                    },
-                    Comments = i.Comments
-                })
-                .ToListAsync();
-
+            var incidents = await service.GetAllIncidentsAsync();
             return Results.Ok(incidents);
-
         });
 
         routes.MapPost("/incident/create", async (
             HttpContext context,
-            SensorDbContext db,
             CreateIncidentDto dto,
+            IIncidentService service,
             UserManager<IdentityUser> userManager) =>
         {
-                var currentUserId = userManager.GetUserId(context.User);
-
-                var incident = new Incident
-            {
-                Type = dto.Type,
-                Status = dto.Status,
-                Sensor_id = dto.SensorId,
-                Creation_date = DateTime.UtcNow,
-                Priority = dto.Priority,
-                Comments = dto.Comments,
-                Responder_id = currentUserId
-                };
-
-            db.Incidents.Add(incident);
-            await db.SaveChangesAsync();
+            var userId = userManager.GetUserId(context.User);
+            await service.CreateIncidentAsync(dto, userId);
             return Results.Ok();
         });
 
-        routes.MapPut("/incident/resolve/{id}", async (int id, IncidentResolutionDto resolutionDto, SensorDbContext db) =>
+        routes.MapPut("/incident/resolve/{id}", async (
+            int id,
+            IncidentResolutionDto dto,
+            IIncidentService service) =>
         {
-            var incident = await db.Incidents.FindAsync(id);
-            if (incident == null)
-                return Results.NotFound();
-
-            incident.Status = "Resolved";
-            incident.Resolution_date = DateTime.UtcNow;
-            incident.Comments = resolutionDto.ResolutionComments;
-
-            await db.SaveChangesAsync();
-            return Results.Ok();
+            var result = await service.ResolveIncidentAsync(id, dto);
+            return result ? Results.Ok() : Results.NotFound();
         });
 
-        routes.MapDelete("/incident/delete/{id}", async (int id, SensorDbContext db) =>
+        routes.MapDelete("/incident/delete/{id}", async (
+            int id,
+            IIncidentService service) =>
         {
-            var incident = await db.Incidents.FindAsync(id);
-            if (incident == null)
-                return Results.NotFound();
-
-            db.Incidents.Remove(incident);
-            await db.SaveChangesAsync();
-            return Results.Ok();
+            var result = await service.DeleteIncidentAsync(id);
+            return result ? Results.Ok() : Results.NotFound();
         });
+
     }
 }

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -6,14 +6,20 @@ namespace SensorApp.Api.Endpoints;
 
 public static class IncidentEndpoints
 {
+    /// <summary>
+    /// Maps the incident-related HTTP endpoints to the application route builder.
+    /// </summary>
+    /// <param name="routes">The route builder for registering HTTP endpoints.</param>
     public static void MapIncidentEndpoints(this IEndpointRouteBuilder routes)
     {
+        // GET endpoint to fetch all incidents
         routes.MapGet("/incidents", async (IIncidentService service) =>
         {
             var incidents = await service.GetAllIncidentsAsync();
             return Results.Ok(incidents);
         });
 
+        // POST endpoint to create a new incident
         routes.MapPost("/incident/create", async (
             HttpContext context,
             CreateIncidentDto dto,
@@ -31,6 +37,7 @@ public static class IncidentEndpoints
             return Results.Ok();
         });
 
+        // PUT endpoint to resolve an existing incident by its ID
         routes.MapPut("/incident/resolve/{id}", async (
             int id,
             IncidentResolutionDto dto,
@@ -40,6 +47,7 @@ public static class IncidentEndpoints
             return result ? Results.Ok() : Results.NotFound();
         });
 
+        // DELETE endpoint to delete an incident by its ID
         routes.MapDelete("/incident/delete/{id}", async (
             int id,
             IIncidentService service) =>

--- a/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/IncidentEndpoints.cs
@@ -21,6 +21,12 @@ public static class IncidentEndpoints
             UserManager<IdentityUser> userManager) =>
         {
             var userId = userManager.GetUserId(context.User);
+
+            if (string.IsNullOrEmpty(dto.Type) || string.IsNullOrEmpty(dto.Status) || dto.SensorId <= 0)
+            {
+                return Results.BadRequest("Invalid data. Ensure Type, Status, and SensorId are provided.");
+            }
+
             await service.CreateIncidentAsync(dto, userId);
             return Results.Ok();
         });

--- a/SensorApp/SensorApp.Api/Endpoints/SensorMapEndpoint.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/SensorMapEndpoint.cs
@@ -10,15 +10,14 @@ namespace SensorApp.Api.Endpoints;
 
 /// <summary>
 /// 
-/// Defines the endpoint to fetch sensor data for the interactive map.
-/// This endpoint is used to retrieve a list of sensors and their measurements.
-/// The endpoint is protected and requires authentication, but is not specific to any one role.
+/// Defines endpoints to fetch sensor data for the interactive map.
+/// The endpoints are protected and require authentication, but are not specific to any one role.
 /// </summary>
 public static class SensorMapEndpoint
 {
 
     /// <summary>
-    /// This method maps the /sensors endpoint to the application.
+    /// This method maps the /sensors endpoints to the application.
     /// <param name="routes">The route builder used to define endpoints in the app.</param>
     /// </summary>
     public static void MapSensorEndpoints(this IEndpointRouteBuilder routes)

--- a/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
+++ b/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
@@ -1,0 +1,11 @@
+﻿using SensorApp.Shared.Dtos.Incident;
+
+namespace SensorApp.Api.Services.Interfaces;
+
+public interface IIncidentService
+{
+    Task<List<IncidentDto>> GetAllIncidentsAsync();
+    Task CreateIncidentAsync(CreateIncidentDto dto, string? responderId);
+    Task<bool> ResolveIncidentAsync(int id, IncidentResolutionDto dto);
+    Task<bool> DeleteIncidentAsync(int id);
+}

--- a/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
+++ b/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
@@ -1,6 +1,6 @@
 ﻿using SensorApp.Shared.Dtos.Incident;
 
-namespace SensorApp.Api.Services.Interfaces;
+namespace SensorApp.Api.Interfaces;
 
 /// <summary>
 /// Defines the contract for incident-related operations.
@@ -18,7 +18,7 @@ public interface IIncidentService
     /// <param name="dto">The data transfer object (DTO) containing incident creation details.</param>
     /// <param name="responderId">The ID of the user who is creating the incident.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task CreateIncidentAsync(CreateIncidentDto dto, string? responderId);
+    Task<IncidentDto?> CreateIncidentAsync(CreateIncidentDto dto, string? responderId);
     /// <summary>
     /// Marks an existing incident as resolved by its ID asynchronously.
     /// </summary>

--- a/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
+++ b/SensorApp/SensorApp.Api/Interfaces/IIncidentService.cs
@@ -2,10 +2,34 @@
 
 namespace SensorApp.Api.Services.Interfaces;
 
+/// <summary>
+/// Defines the contract for incident-related operations.
+/// </summary>
 public interface IIncidentService
 {
+    /// <summary>
+    /// Fetches all incidents from the data source asynchronously.
+    /// </summary>
+    /// <returns>A list of <see cref="IncidentDto"/> representing all incidents.</returns>
     Task<List<IncidentDto>> GetAllIncidentsAsync();
+    /// <summary>
+    /// Creates a new incident in the data source asynchronously.
+    /// </summary>
+    /// <param name="dto">The data transfer object (DTO) containing incident creation details.</param>
+    /// <param name="responderId">The ID of the user who is creating the incident.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task CreateIncidentAsync(CreateIncidentDto dto, string? responderId);
+    /// <summary>
+    /// Marks an existing incident as resolved by its ID asynchronously.
+    /// </summary>
+    /// <param name="id">The ID of the incident to resolve.</param>
+    /// <param name="dto">The data transfer object (DTO) containing resolution details.</param>
+    /// <returns>A task representing the asynchronous operation. Returns true if the incident was resolved, otherwise false.</returns>
     Task<bool> ResolveIncidentAsync(int id, IncidentResolutionDto dto);
+    /// <summary>
+    /// Deletes an existing incident by its ID asynchronously.
+    /// </summary>
+    /// <param name="id">The ID of the incident to delete.</param>
+    /// <returns>A task representing the asynchronous operation. Returns true if the incident was successfully deleted, otherwise false.</returns>
     Task<bool> DeleteIncidentAsync(int id);
 }

--- a/SensorApp/SensorApp.Api/Program.cs
+++ b/SensorApp/SensorApp.Api/Program.cs
@@ -88,6 +88,7 @@ public class Program
 
         builder.Services.AddScoped<ITokenService, TokenService>()
                         .AddScoped<IAuthService, AuthService>();
+
         builder.Services.AddScoped<IIncidentService, IncidentService>();
 
         builder.Host.UseSerilog((ctx, lc) => lc.WriteTo.Console().ReadFrom.Configuration(ctx.Configuration));

--- a/SensorApp/SensorApp.Api/Program.cs
+++ b/SensorApp/SensorApp.Api/Program.cs
@@ -112,6 +112,7 @@ public class Program
         app.MapSensorEndpoints();
         app.MapMeasurandEndpoints();
         app.MapMeasurementEndpoints();
+        app.MapIncidentEndpoints();
 
         await app.RunAsync();
     }

--- a/SensorApp/SensorApp.Api/Program.cs
+++ b/SensorApp/SensorApp.Api/Program.cs
@@ -11,6 +11,8 @@ using SensorApp.Shared.Models;
 using Serilog;
 using System.Text;
 using SensorApp.Database.Data.CSVHandling;
+using SensorApp.Api.Services.Interfaces;
+using SensorApp.Api.Services;
 
 namespace SensorApp.Api;
 
@@ -86,6 +88,7 @@ public class Program
 
         builder.Services.AddScoped<ITokenService, TokenService>()
                         .AddScoped<IAuthService, AuthService>();
+        builder.Services.AddScoped<IIncidentService, IncidentService>();
 
         builder.Host.UseSerilog((ctx, lc) => lc.WriteTo.Console().ReadFrom.Configuration(ctx.Configuration));
 

--- a/SensorApp/SensorApp.Api/Program.cs
+++ b/SensorApp/SensorApp.Api/Program.cs
@@ -11,7 +11,7 @@ using SensorApp.Shared.Models;
 using Serilog;
 using System.Text;
 using SensorApp.Database.Data.CSVHandling;
-using SensorApp.Api.Services.Interfaces;
+using SensorApp.Api.Interfaces;
 using SensorApp.Api.Services;
 
 namespace SensorApp.Api;

--- a/SensorApp/SensorApp.Api/Services/IncidentService.cs
+++ b/SensorApp/SensorApp.Api/Services/IncidentService.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SensorApp.Api.Services.Interfaces;
+using SensorApp.Database.Data;
+using SensorApp.Database.Models;
+using SensorApp.Shared.Dtos.Admin;
+using SensorApp.Shared.Dtos;
+using SensorApp.Shared.Dtos.Incident;
+
+namespace SensorApp.Api.Services;
+
+public class IncidentService : IIncidentService
+{
+    private readonly SensorDbContext _db;
+
+    public IncidentService(SensorDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<IncidentDto>> GetAllIncidentsAsync()
+    {
+        return await _db.Incidents
+            .Include(i => i.Sensor)
+            .Include(i => i.Responder)
+            .Select(i => new IncidentDto
+            {
+                Id = i.Id,
+                Type = i.Type,
+                Status = i.Status,
+                Sensor_id = i.Sensor_id,
+                Sensor = new SensorDto
+                {
+                    Id = i.Sensor.Id,
+                    Type = i.Sensor.Type,
+                    Latitude = i.Sensor.Latitude,
+                    Longitude = i.Sensor.Longitude,
+                    Site_zone = i.Sensor.Site_zone,
+                    Status = i.Sensor.Status
+                },
+                Creation_date = i.Creation_date,
+                Priority = i.Priority,
+                Resolution_date = i.Resolution_date,
+                Responder_id = i.Responder_id,
+                Responder = new UserWithRoleDto
+                {
+                    Id = i.Responder.Id,
+                    Username = i.Responder.UserName
+                },
+                Comments = i.Comments
+            })
+            .ToListAsync();
+    }
+
+    public async Task CreateIncidentAsync(CreateIncidentDto dto, string? responderId)
+    {
+        var incident = new Incident
+        {
+            Type = dto.Type,
+            Status = dto.Status,
+            Sensor_id = dto.SensorId,
+            Creation_date = DateTime.UtcNow,
+            Priority = dto.Priority,
+            Comments = dto.Comments,
+            Responder_id = responderId
+        };
+
+        _db.Incidents.Add(incident);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task<bool> ResolveIncidentAsync(int id, IncidentResolutionDto dto)
+    {
+        var incident = await _db.Incidents.FindAsync(id);
+        if (incident == null) return false;
+
+        incident.Status = "Resolved";
+        incident.Resolution_date = DateTime.UtcNow;
+        incident.Comments = dto.ResolutionComments;
+
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> DeleteIncidentAsync(int id)
+    {
+        var incident = await _db.Incidents.FindAsync(id);
+        if (incident == null) return false;
+
+        _db.Incidents.Remove(incident);
+        await _db.SaveChangesAsync();
+        return true;
+    }
+}

--- a/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
+++ b/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
@@ -2,6 +2,8 @@
 using Microsoft.EntityFrameworkCore;
 using SensorApp.Shared.Enums;
 using SensorApp.Database.Models;
+using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
 
 namespace SensorApp.Database.Data.DataSeeder;
 
@@ -76,18 +78,18 @@ public static class ModelBuilderExtensions
         modelBuilder.Entity<IdentityUserRole<string>>().HasData(
             new IdentityUserRole<string>
             {
-                RoleId = "3d52c1e5-6aec-45de-91c1-e0ebf20464e3",   
-                UserId = "fab66dad-9f12-45a0-9fd8-6352336a696d"   
+                RoleId = "3d52c1e5-6aec-45de-91c1-e0ebf20464e3",
+                UserId = "fab66dad-9f12-45a0-9fd8-6352336a696d"
             },
             new IdentityUserRole<string>
             {
-                RoleId = "71136dd8-0a29-4d9a-b3fe-bd176ba7aa9c",   
-                UserId = "99166c0c-7f14-442b-8c57-9141f3ac1681"    
+                RoleId = "71136dd8-0a29-4d9a-b3fe-bd176ba7aa9c",
+                UserId = "99166c0c-7f14-442b-8c57-9141f3ac1681"
             },
             new IdentityUserRole<string>
             {
-                RoleId = "9b7f193f-bfc4-4eb7-927f-55960e45a82a",    
-                UserId = "1243c642-7fdf-4224-9404-02dd6ac95bc5"   
+                RoleId = "9b7f193f-bfc4-4eb7-927f-55960e45a82a",
+                UserId = "1243c642-7fdf-4224-9404-02dd6ac95bc5"
             }
         );
     }
@@ -231,5 +233,23 @@ public static class ModelBuilderExtensions
                 }
             );
     }
+
+    public static void SeedIncidents(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Incident>().HasData(
+            new Incident
+            {
+                Id = 1,
+                Type = "Max threshold breach",
+                Status = "Open",
+                Sensor_id = 1,
+                Creation_date = DateTime.UtcNow,
+                Priority = "High",
+                Resolution_date = null,
+                Responder_id = "99166c0c-7f14-442b-8c57-9141f3ac1681",
+                Comments = "Max threshold breach for Nitrogen Dioxide"
+            }
+            );
+        }
 }
 

--- a/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
+++ b/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
@@ -2,7 +2,6 @@
 using Microsoft.EntityFrameworkCore;
 using SensorApp.Shared.Enums;
 using SensorApp.Database.Models;
-using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations;
 
 namespace SensorApp.Database.Data.DataSeeder;

--- a/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
+++ b/SensorApp/SensorApp.Database/Data/DataSeeder/ModelBuilderExtensions.cs
@@ -240,16 +240,16 @@ public static class ModelBuilderExtensions
             new Incident
             {
                 Id = 1,
-                Type = "Max threshold breach",
-                Status = "Open",
+                Type = IncidentType.MaxThresholdBreached,
+                Status = 0,
                 Sensor_id = 1,
                 Creation_date = DateTime.UtcNow,
-                Priority = "High",
+                Priority = IncidentPriority.High,
                 Resolution_date = null,
                 Responder_id = "99166c0c-7f14-442b-8c57-9141f3ac1681",
                 Comments = "Max threshold breach for Nitrogen Dioxide"
             }
-            );
-        }
+         );
+    }
 }
 

--- a/SensorApp/SensorApp.Database/Data/SensorDbContext.cs
+++ b/SensorApp/SensorApp.Database/Data/SensorDbContext.cs
@@ -21,5 +21,6 @@ public class SensorDbContext(DbContextOptions<SensorDbContext> options) : Identi
         builder.SeedIdentity();
         builder.SeedMeasurands();
         builder.SeedSensors();
+        builder.SeedIncidents();
     }
 }

--- a/SensorApp/SensorApp.Database/Data/SensorDbContext.cs
+++ b/SensorApp/SensorApp.Database/Data/SensorDbContext.cs
@@ -15,6 +15,8 @@ public class SensorDbContext(DbContextOptions<SensorDbContext> options) : Identi
     public DbSet<Measurand> Measurand { get; set; }
     public DbSet<Measurement> Measurement { get; set; }
     public DbSet<Sensor> Sensors { get; set; }
+    public DbSet<Incident> Incidents { get; set; }
+    
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/SensorApp/SensorApp.Database/Models/Incident.cs
+++ b/SensorApp/SensorApp.Database/Models/Incident.cs
@@ -6,8 +6,8 @@ using Microsoft.AspNetCore.Identity;
 namespace SensorApp.Database.Models;
 
 /// <summary>
-/// Represents an incident or anomaly that can occur at a sensor. 
-/// The <see cref="Incident"/> model includes metadata about the incident itself, its related sensor and individuals related to it.
+/// Represents an incident or anomaly that can occur in relation to a sensor. 
+/// The <see cref="Incident"/> model includes metadata about the incident itself, its related sensor and users related to it.
 /// </summary>
 [Table("incident")]
 public class Incident : BaseEntity
@@ -17,15 +17,17 @@ public class Incident : BaseEntity
     [Required]
     public string Status { get; set; }
     [Required]
+    [ForeignKey("Sensor_id")]
     public Sensor Sensor { get; set; }
     [Required]
     public int Sensor_id { get; set; }
     [Required]
-    public DateTime Date { get; set; }
+    public DateTime Creation_date { get; set; }
     [Required]
     public string Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
+    [ForeignKey("Responder_id")]
     public IdentityUser Responder { get; set; }
-    public int Responder_id { get; set; }
+    public string Responder_id { get; set; }
     public string? Comments { get; set; }
 }

--- a/SensorApp/SensorApp.Database/Models/Incident.cs
+++ b/SensorApp/SensorApp.Database/Models/Incident.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Identity;
+
+namespace SensorApp.Database.Models;
+
+/// <summary>
+/// Represents an incident or anomaly that can occur at a sensor. 
+/// The <see cref="Incident"/> model includes metadata about the incident itself, its related sensor and individuals related to it.
+/// </summary>
+[Table("incident")]
+public class Incident : BaseEntity
+{
+    [Required]
+    public string Type { get; set; }
+    [Required]
+    public string Status { get; set; }
+    [Required]
+    public Sensor Sensor { get; set; }
+    [Required]
+    public int Sensor_id { get; set; }
+    [Required]
+    public DateTime Date { get; set; }
+    [Required]
+    public string Priority { get; set; }
+    public DateTime? Resolution_date { get; set; }
+    public IdentityUser Responder { get; set; }
+    public int Responder_id { get; set; }
+    public string? Comments { get; set; }
+}

--- a/SensorApp/SensorApp.Database/Models/Incident.cs
+++ b/SensorApp/SensorApp.Database/Models/Incident.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Identity;
+using SensorApp.Shared.Enums;
 
 namespace SensorApp.Database.Models;
 
@@ -13,9 +14,9 @@ namespace SensorApp.Database.Models;
 public class Incident : BaseEntity
 {
     [Required]
-    public string Type { get; set; }
+    public IncidentType Type { get; set; }
     [Required]
-    public string Status { get; set; }
+    public IncidentStatus Status { get; set; }
     [Required]
     [ForeignKey("Sensor_id")]
     public Sensor Sensor { get; set; }
@@ -24,7 +25,7 @@ public class Incident : BaseEntity
     [Required]
     public DateTime Creation_date { get; set; }
     [Required]
-    public string Priority { get; set; }
+    public IncidentPriority Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
     [ForeignKey("Responder_id")]
     public IdentityUser Responder { get; set; }

--- a/SensorApp/SensorApp.Maui/App.xaml
+++ b/SensorApp/SensorApp.Maui/App.xaml
@@ -7,7 +7,7 @@
 
     <Application.Resources>
         <ResourceDictionary>
-
+    
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
@@ -16,6 +16,7 @@
             <utils:EnumDisplayNameConverter x:Key="EnumDisplayName" />
             <utils:IncidentDisplayNameConverter x:Key="IncidentLabelConverter" />
             <utils:InverseBoolConverter x:Key="InverseBoolConverter" />
+            <utils:NullToPlaceholderConverter x:Key="NullToPlaceholderConverter" />
 
         </ResourceDictionary>
     </Application.Resources>

--- a/SensorApp/SensorApp.Maui/App.xaml
+++ b/SensorApp/SensorApp.Maui/App.xaml
@@ -15,6 +15,7 @@
 
             <utils:EnumDisplayNameConverter x:Key="EnumDisplayName" />
             <utils:IncidentDisplayNameConverter x:Key="IncidentLabelConverter" />
+            <utils:InverseBoolConverter x:Key="InverseBoolConverter" />
 
         </ResourceDictionary>
     </Application.Resources>

--- a/SensorApp/SensorApp.Maui/App.xaml
+++ b/SensorApp/SensorApp.Maui/App.xaml
@@ -14,6 +14,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <utils:EnumDisplayNameConverter x:Key="EnumDisplayName" />
+            <utils:IncidentDisplayNameConverter x:Key="IncidentLabelConverter" />
 
         </ResourceDictionary>
     </Application.Resources>

--- a/SensorApp/SensorApp.Maui/AppShell.xaml.cs
+++ b/SensorApp/SensorApp.Maui/AppShell.xaml.cs
@@ -16,5 +16,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(EditUserPage), typeof(EditUserPage));
         Routing.RegisterRoute(nameof(HistoricalDataPage), typeof(HistoricalDataPage));
         Routing.RegisterRoute(nameof(IncidentList), typeof(IncidentList));
+        Routing.RegisterRoute(nameof(CreateIncidentPage), typeof(CreateIncidentPage));
     }
 }

--- a/SensorApp/SensorApp.Maui/AppShell.xaml.cs
+++ b/SensorApp/SensorApp.Maui/AppShell.xaml.cs
@@ -15,6 +15,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(SensorMapPage), typeof(SensorMapPage));
         Routing.RegisterRoute(nameof(EditUserPage), typeof(EditUserPage));
         Routing.RegisterRoute(nameof(HistoricalDataPage), typeof(HistoricalDataPage));
-
+        Routing.RegisterRoute(nameof(IncidentList), typeof(IncidentList));
     }
 }

--- a/SensorApp/SensorApp.Maui/AppShell.xaml.cs
+++ b/SensorApp/SensorApp.Maui/AppShell.xaml.cs
@@ -17,5 +17,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(HistoricalDataPage), typeof(HistoricalDataPage));
         Routing.RegisterRoute(nameof(IncidentList), typeof(IncidentList));
         Routing.RegisterRoute(nameof(CreateIncidentPage), typeof(CreateIncidentPage));
+        Routing.RegisterRoute(nameof(IncidentDetailPage), typeof(IncidentDetailPage));
+
     }
 }

--- a/SensorApp/SensorApp.Maui/MauiProgram.cs
+++ b/SensorApp/SensorApp.Maui/MauiProgram.cs
@@ -81,6 +81,7 @@ public static class MauiProgram
 
         builder.Services.AddTransient<IncidentList>();
         builder.Services.AddTransient<CreateIncidentPage>();
+        builder.Services.AddTransient<IncidentDetailPage>();
 
         builder.Services.AddSingleton<LoadingPageViewModel>();
         builder.Services.AddSingleton<LoginViewModel>();
@@ -91,6 +92,7 @@ public static class MauiProgram
         builder.Services.AddTransient<HistoricalDataViewModel>();
         builder.Services.AddTransient<IncidentListViewModel>();
         builder.Services.AddTransient<CreateIncidentViewModel>();
+        builder.Services.AddTransient<IncidentDetailViewModel>();
 
         return builder.Build();
     }

--- a/SensorApp/SensorApp.Maui/MauiProgram.cs
+++ b/SensorApp/SensorApp.Maui/MauiProgram.cs
@@ -55,12 +55,7 @@ public static class MauiProgram
         builder.Services.AddHttpClient<IMeasurandService, MeasurandService>().ConfigureApiHttpClient();
         builder.Services.AddHttpClient<IMeasurementService, MeasurementService>().ConfigureApiHttpClient();
 
-        builder.Services.AddHttpClient<IIncidentApiService, IncidentApiService>()
-            .ConfigureApiHttpClient()
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-            {
-                ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
-            });
+        builder.Services.AddHttpClient<IIncidentApiService, IncidentApiService>().ConfigureApiHttpClient();
 
         builder.Services.AddSingleton<ITokenProvider, TokenProvider>();
         builder.Services.AddSingleton<IMenuBuilder, MenuBuilder>();

--- a/SensorApp/SensorApp.Maui/MauiProgram.cs
+++ b/SensorApp/SensorApp.Maui/MauiProgram.cs
@@ -79,6 +79,8 @@ public static class MauiProgram
         builder.Services.AddTransient<EditUserPage>();
         builder.Services.AddTransient<HistoricalDataPage>();
 
+        builder.Services.AddTransient<IncidentList>();
+        builder.Services.AddTransient<CreateIncidentPage>();
 
         builder.Services.AddSingleton<LoadingPageViewModel>();
         builder.Services.AddSingleton<LoginViewModel>();
@@ -88,7 +90,7 @@ public static class MauiProgram
         builder.Services.AddTransient<EditUserViewModel>();
         builder.Services.AddTransient<HistoricalDataViewModel>();
         builder.Services.AddTransient<IncidentListViewModel>();
-        builder.Services.AddTransient<IncidentList>();
+        builder.Services.AddTransient<CreateIncidentViewModel>();
 
         return builder.Build();
     }

--- a/SensorApp/SensorApp.Maui/MauiProgram.cs
+++ b/SensorApp/SensorApp.Maui/MauiProgram.cs
@@ -50,7 +50,7 @@ public static class MauiProgram
         //check this is possible error 
         builder.Services.AddHttpClient<IAuthService, AuthService>().ConfigureApiHttpClient();
 
-        builder.Services.AddHttpClient<SensorApiService>().ConfigureApiHttpClient();
+        builder.Services.AddHttpClient<ISensorApiService, SensorApiService>().ConfigureApiHttpClient();
         builder.Services.AddHttpClient<IAdminService, AdminService>().ConfigureApiHttpClient();
         builder.Services.AddHttpClient<IMeasurandService, MeasurandService>().ConfigureApiHttpClient();
         builder.Services.AddHttpClient<IMeasurementService, MeasurementService>().ConfigureApiHttpClient();

--- a/SensorApp/SensorApp.Maui/MauiProgram.cs
+++ b/SensorApp/SensorApp.Maui/MauiProgram.cs
@@ -55,6 +55,13 @@ public static class MauiProgram
         builder.Services.AddHttpClient<IMeasurandService, MeasurandService>().ConfigureApiHttpClient();
         builder.Services.AddHttpClient<IMeasurementService, MeasurementService>().ConfigureApiHttpClient();
 
+        builder.Services.AddHttpClient<IIncidentApiService, IncidentApiService>()
+            .ConfigureApiHttpClient()
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
+            });
+
         builder.Services.AddSingleton<ITokenProvider, TokenProvider>();
         builder.Services.AddSingleton<IMenuBuilder, MenuBuilder>();
         builder.Services.AddSingleton<ISensorAnalysisService, SensorAnalysisService>();
@@ -80,6 +87,8 @@ public static class MauiProgram
         builder.Services.AddTransient<NewUserViewModel>();
         builder.Services.AddTransient<EditUserViewModel>();
         builder.Services.AddTransient<HistoricalDataViewModel>();
+        builder.Services.AddTransient<IncidentListViewModel>();
+        builder.Services.AddTransient<IncidentList>();
 
         return builder.Build();
     }

--- a/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
+++ b/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
@@ -104,6 +104,9 @@
 	  <Compile Update="Views\Pages\AdminUsersPage.xaml.cs">
 	    <DependentUpon>AdminUsersPage.xaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="Views\Pages\IncidentList.xaml.cs">
+	    <DependentUpon>IncidentList.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Views\Pages\SensorMapPage.xaml.cs">
 	    <DependentUpon>SensorMapPage.xaml</DependentUpon>
 	  </Compile>
@@ -123,6 +126,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\Pages\LoginPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\Pages\IncidentList.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\Pages\NewUserPage.xaml">

--- a/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
+++ b/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
@@ -116,6 +116,9 @@
 	  <MauiXaml Update="Views\Controls\FlyOutHeader.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\Pages\CreateIncidentPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\Pages\EditUserPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
+++ b/SensorApp/SensorApp.Maui/SensorApp.Maui.csproj
@@ -107,6 +107,9 @@
 	  <Compile Update="Views\Pages\IncidentList.xaml.cs">
 	    <DependentUpon>IncidentList.xaml</DependentUpon>
 	  </Compile>
+	  <Compile Update="Views\Pages\IncidentDetailPage.xaml.cs">
+	    <DependentUpon>IncidentDetailPage.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="Views\Pages\SensorMapPage.xaml.cs">
 	    <DependentUpon>SensorMapPage.xaml</DependentUpon>
 	  </Compile>
@@ -132,6 +135,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\Pages\IncidentList.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\Pages\IncidentDetailPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\Pages\NewUserPage.xaml">

--- a/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using SensorApp.Shared.Dtos.Incident;
+
+namespace SensorApp.Maui.Utils;
+
+public class IncidentDisplayNameConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is IncidentDto incident)
+        {
+            return $"{incident.Sensor?.Type} Sensor {incident.Sensor?.Id} - {incident.Creation_date:dd MMM yyyy}";
+        }
+
+        return string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+};

--- a/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
@@ -12,7 +12,7 @@ public class IncidentDisplayNameConverter : IValueConverter
     {
         if (value is IncidentDto incident)
         {
-            return $"{incident.Sensor?.Type} Sensor {incident.Sensor?.Id} - {incident.Creation_date:dd MMM yyyy}";
+            return $"{incident.Sensor?.Type} Sensor {incident.Sensor?.Id} - {incident.Type} ({incident.Creation_date})";
         }
 
         return string.Empty;

--- a/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
@@ -1,13 +1,18 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Globalization;
-using System.Reflection;
-using System.Text.RegularExpressions;
+﻿using System.Globalization;
 using SensorApp.Shared.Dtos.Incident;
 
 namespace SensorApp.Maui.Utils;
 
 public class IncidentDisplayNameConverter : IValueConverter
 {
+    /// <summary>
+    /// Converts an incident object to a display-friendly string representation.
+    /// </summary>
+    /// <param name="value">The value to convert, expected to be of type <see cref="IncidentDto"/>.</param>
+    /// <param name="targetType">The target type of the conversion (not used in this implementation).</param>
+    /// <param name="parameter">An optional parameter (not used in this implementation).</param>
+    /// <param name="culture">The culture info used for the conversion (not used in this implementation).</param>
+    /// <returns>A formatted string representing the incident's sensor type, sensor ID, incident type, and creation date.</returns>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is IncidentDto incident)
@@ -18,6 +23,9 @@ public class IncidentDisplayNameConverter : IValueConverter
         return string.Empty;
     }
 
+    /// <summary>
+    /// Not implemented, as this converter is only used for one-way binding.
+    /// </summary>
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
         throw new NotImplementedException();

--- a/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/IncidentDisplayNameConverter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Globalization;
 using SensorApp.Shared.Dtos.Incident;
+using System.Reflection;
+using System.ComponentModel.DataAnnotations;
 
 namespace SensorApp.Maui.Utils;
 
@@ -17,10 +19,17 @@ public class IncidentDisplayNameConverter : IValueConverter
     {
         if (value is IncidentDto incident)
         {
-            return $"{incident.Sensor?.Type} Sensor {incident.Sensor?.Id} - {incident.Type} ({incident.Creation_date})";
+            var incidentTypeDisplayName = GetEnumDisplayName(incident.Type);
+            return $"Sensor {incident.Sensor?.Id} ({incident.Sensor?.Type}) - {incidentTypeDisplayName} ({incident.Creation_date})";
         }
 
         return string.Empty;
+    }
+    private string GetEnumDisplayName(Enum value)
+    {
+        var field = value.GetType().GetField(value.ToString());
+        var attribute = field?.GetCustomAttribute<DisplayAttribute>();
+        return attribute?.Name ?? value.ToString();
     }
 
     /// <summary>

--- a/SensorApp/SensorApp.Maui/Utils/InverseBoolConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/InverseBoolConverter.cs
@@ -2,11 +2,33 @@
 using Microsoft.Maui.Controls;
 
 namespace SensorApp.Maui.Utils;
+
+/// <summary>
+/// A value converter that inverts a boolean value.
+/// This is useful for data binding scenarios where you need to toggle the boolean value in the UI.
+/// </summary>
 public class InverseBoolConverter : IValueConverter
 {
+    /// <summary>
+    /// Converts a boolean value to its inverse.
+    /// </summary>
+    /// <param name="value">The value to be converted (should be a boolean).</param>
+    /// <param name="targetType">The type of the binding target property (ot used in this implementation).</param>
+    /// <param name="parameter">Additional parameter for the conversion (ot used in this implementation).</param>
+    /// <param name="culture">Culture information (ot used in this implementation).</param>
+    /// <returns>The inverted boolean value (true becomes false, and false becomes true).</returns>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         => value is bool b && !b;
 
+    /// <summary>
+    /// Converts the value back to its original state (inverse of inverse).
+    /// Since it's the same operation, this method behaves like Convert().
+    /// </summary>
+    /// <param name="value">The value to be converted (should be a boolean).</param>
+    /// <param name="targetType">The type of the binding target property (ot used in this implementation).</param>
+    /// <param name="parameter">Additional parameter for the conversion (ot used in this implementation).</param>
+    /// <param name="culture">Culture information (ot used in this implementation).</param>
+    /// <returns>The inverted boolean value (true becomes false, and false becomes true).</returns>
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => value is bool b && !b;
 }

--- a/SensorApp/SensorApp.Maui/Utils/InverseBoolConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/InverseBoolConverter.cs
@@ -1,0 +1,12 @@
+﻿using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace SensorApp.Maui.Utils;
+public class InverseBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b && !b;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b && !b;
+}

--- a/SensorApp/SensorApp.Maui/Utils/NullToPlaceholderConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/NullToPlaceholderConverter.cs
@@ -4,13 +4,39 @@ using Microsoft.Maui.Controls;
 
 namespace SensorApp.Maui.Utils;
 
+/// <summary>
+/// A value converter that converts null or empty strings to a placeholder value ("--").
+/// This is useful for displaying a default placeholder in the UI when a value is null or empty.
+/// </summary>
 public class NullToPlaceholderConverter : IValueConverter
 {
+    /// <summary>
+    /// Converts a null or empty string to a placeholder value ("--").
+    /// If the value is not null or empty, it returns the original value.
+    /// </summary>
+    /// <param name="value">The value to be converted (could be null or empty).</param>
+    /// <param name="targetType">The type of the binding target property (not used here).</param>
+    /// <param name="parameter">Additional parameter for the conversion (not used here).</param>
+    /// <param name="culture">Culture information (not used here).</param>
+    /// <returns>
+    /// The placeholder string "--" if the value is null or empty, otherwise returns the original value.
+    /// </returns>
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         return string.IsNullOrWhiteSpace(value?.ToString()) ? "--" : value;
     }
 
+    /// <summary>
+    /// Converts the placeholder back to the original value. 
+    /// In this case, this method simply returns the value, as no special logic is needed for ConvertBack.
+    /// </summary>
+    /// <param name="value">The value to be converted (the placeholder or the original value).</param>
+    /// <param name="targetType">The type of the binding target property (not used here).</param>
+    /// <param name="parameter">Additional parameter for the conversion (not used here).</param>
+    /// <param name="culture">Culture information (not used here).</param>
+    /// <returns>
+    /// The original value or the placeholder value (unchanged).
+    /// </returns>
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
         return value;

--- a/SensorApp/SensorApp.Maui/Utils/NullToPlaceholderConverter.cs
+++ b/SensorApp/SensorApp.Maui/Utils/NullToPlaceholderConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace SensorApp.Maui.Utils;
+
+public class NullToPlaceholderConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return string.IsNullOrWhiteSpace(value?.ToString()) ? "--" : value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value;
+    }
+}

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -95,14 +95,19 @@ public partial class CreateIncidentViewModel : BaseViewModel
 
             var success = await _incidentService.AddIncidentAsync(token, newIncident);
             if (success)
+            {
                 await Shell.Current.DisplayAlert("Success", "Incident created!", "OK");
                 await Shell.Current.GoToAsync("..");
-        }
-        catch
-        {
+            }
+            else
             {
                 await Shell.Current.DisplayAlert("Error", "Failed to create incident report.", "OK");
             }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error while creating incident: {ex.Message}");
+            await Shell.Current.DisplayAlert("Error", "Failed to create incident report.", "OK");
         }
     }
 }

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -8,6 +8,11 @@ using SensorApp.Shared.Models;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for creating a new incident report. 
+/// It handles the logic for loading sensors, setting up incident types and priorities, 
+/// and creating an incident report via the API service.
+/// </summary>
 public partial class CreateIncidentViewModel : BaseViewModel
 {
     private readonly IIncidentApiService _incidentService;
@@ -23,10 +28,18 @@ public partial class CreateIncidentViewModel : BaseViewModel
 
     public List<string> TypeOptions { get; } = ["Max threshold breach", "Min threshold breach", "Sensor unresponsive"];
     public List<string> PriorityOptions { get; } = ["High", "Medium", "Low"];
+
     public ObservableCollection<SensorModel> Sensors { get; } = new();
+
     [ObservableProperty]
     private bool isLoadingSensors;
 
+    /// <summary>
+    /// Constructor that initializes services and loads sensor data asynchronously.
+    /// </summary>
+    /// <param name="incidentService">The service for creating incidents.</param>
+    /// <param name="sensorService">The service for fetching sensors.</param>
+    /// <param name="tokenProvider">The provider for authentication tokens.</param>
     public CreateIncidentViewModel(IIncidentApiService incidentService, ISensorApiService sensorService, ITokenProvider tokenProvider)
     {
         _incidentService = incidentService;
@@ -38,6 +51,11 @@ public partial class CreateIncidentViewModel : BaseViewModel
 
         _ = LoadSensorsAsync();
     }
+
+    /// <summary>
+    /// Asynchronously loads the list of sensors from the sensor service and updates the sensor list.
+    /// Also sets the default selected sensor.
+    /// </summary>
     private async Task LoadSensorsAsync()
     {
         isLoadingSensors = true;
@@ -64,12 +82,21 @@ public partial class CreateIncidentViewModel : BaseViewModel
         }
 
     }
+
+    /// <summary>
+    /// Triggered when the selected sensor changes. Updates the stored selectedSensorID based on the selected sensor.
+    /// </summary>
+    /// <param name="value">The newly selected sensor.</param>
     partial void OnSelectedSensorChanged(SensorModel value)
     {
         if (value != null)
             selectedSensorId = value.Id;
     }
 
+    /// <summary>
+    /// Command method that creates a new incident report by calling the incident service.
+    /// It also handles error display and navigation after creating an incident.
+    /// </summary>
     [RelayCommand]
     public async Task CreateIncidentAsync()
     {
@@ -89,8 +116,6 @@ public partial class CreateIncidentViewModel : BaseViewModel
                 Priority = SelectedPriority,
                 Comments = Comments,
             };
-
-            Console.WriteLine(newIncident.SensorId);
 
             var success = await _incidentService.AddIncidentAsync(token, newIncident);
             if (success)

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -1,0 +1,92 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SensorApp.Shared.Interfaces;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Services;
+using SensorApp.Shared.Dtos;
+using System.Collections.ObjectModel;
+using SensorApp.Shared.Models;
+
+namespace SensorApp.Maui.ViewModels;
+
+public partial class CreateIncidentViewModel : BaseViewModel
+{
+    private readonly IIncidentApiService _incidentService;
+    private readonly SensorApiService _sensorService;
+    private readonly ITokenProvider _tokenProvider;
+
+    [ObservableProperty] private SensorModel selectedSensor;
+    [ObservableProperty] private string selectedType;
+    [ObservableProperty] private int selectedSensorId;
+    [ObservableProperty] private string selectedPriority;
+
+    [ObservableProperty] private string comments;
+
+    public List<string> TypeOptions { get; } = ["Max threshold breach", "Min threshold breach", "Sensor unresponsive"];
+    public List<string> PriorityOptions { get; } = ["High", "Medium", "Low"];
+    public ObservableCollection<SensorModel> Sensors { get; } = new();
+
+    public CreateIncidentViewModel(IIncidentApiService incidentService, SensorApiService sensorService, ITokenProvider tokenProvider)
+    {
+        _incidentService = incidentService;
+        _sensorService = sensorService;
+        _tokenProvider = tokenProvider;
+
+        SelectedType = TypeOptions.First();
+        SelectedPriority = PriorityOptions.First();
+
+        _ = LoadSensorsAsync();
+    }
+    private async Task LoadSensorsAsync()
+    {
+        var token = await _tokenProvider.GetTokenAsync();
+        var sensors = await _sensorService.GetSensorsAsync(token);
+        Sensors.Clear();
+        foreach (var s in sensors)
+        {
+            Sensors.Add(s);
+        }
+
+        SelectedSensor = Sensors.FirstOrDefault();
+    }
+    partial void OnSelectedSensorChanged(SensorModel value)
+    {
+        if (value != null)
+            selectedSensorId = value.Id;
+    }
+
+    [RelayCommand]
+    public async Task CreateIncidentAsync()
+    {
+        try
+        {
+            var token = await _tokenProvider.GetTokenAsync();
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new Exception("No auth token");
+            }
+
+            var newIncident = new CreateIncidentDto
+            {
+                Type = SelectedType,
+                Status = "Open",
+                SensorId = SelectedSensorId,
+                Priority = SelectedPriority,
+                Comments = Comments,
+            };
+
+            Console.WriteLine(newIncident.SensorId);
+
+            var success = await _incidentService.AddIncidentAsync(token, newIncident);
+            if (success)
+                await Shell.Current.DisplayAlert("Success", "Incident created!", "OK");
+                await Shell.Current.GoToAsync("..");
+        }
+        catch
+        {
+            {
+                await Shell.Current.DisplayAlert("Error", "Failed to create incident report.", "OK");
+            }
+        }
+    }
+}

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -25,6 +25,8 @@ public partial class CreateIncidentViewModel : BaseViewModel
     public List<string> TypeOptions { get; } = ["Max threshold breach", "Min threshold breach", "Sensor unresponsive"];
     public List<string> PriorityOptions { get; } = ["High", "Medium", "Low"];
     public ObservableCollection<SensorModel> Sensors { get; } = new();
+    [ObservableProperty]
+    private bool isLoadingSensors;
 
     public CreateIncidentViewModel(IIncidentApiService incidentService, SensorApiService sensorService, ITokenProvider tokenProvider)
     {
@@ -39,15 +41,29 @@ public partial class CreateIncidentViewModel : BaseViewModel
     }
     private async Task LoadSensorsAsync()
     {
-        var token = await _tokenProvider.GetTokenAsync();
-        var sensors = await _sensorService.GetSensorsAsync(token);
-        Sensors.Clear();
-        foreach (var s in sensors)
+        isLoadingSensors = true;
+
+        try
         {
-            Sensors.Add(s);
+            var token = await _tokenProvider.GetTokenAsync();
+            var sensors = await _sensorService.GetSensorsAsync(token);
+            Sensors.Clear();
+            foreach (var s in sensors)
+            {
+                Sensors.Add(s);
+            }
+
+            SelectedSensor = Sensors.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to load sensors: {ex.Message}");
+        }
+        finally
+        {
+            IsLoadingSensors = false;
         }
 
-        SelectedSensor = Sensors.FirstOrDefault();
     }
     partial void OnSelectedSensorChanged(SensorModel value)
     {

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -2,7 +2,6 @@
 using CommunityToolkit.Mvvm.Input;
 using SensorApp.Shared.Interfaces;
 using SensorApp.Shared.Dtos.Incident;
-using SensorApp.Shared.Services;
 using SensorApp.Shared.Dtos;
 using System.Collections.ObjectModel;
 using SensorApp.Shared.Models;
@@ -12,7 +11,7 @@ namespace SensorApp.Maui.ViewModels;
 public partial class CreateIncidentViewModel : BaseViewModel
 {
     private readonly IIncidentApiService _incidentService;
-    private readonly SensorApiService _sensorService;
+    private readonly ISensorApiService _sensorService;
     private readonly ITokenProvider _tokenProvider;
 
     [ObservableProperty] private SensorModel selectedSensor;
@@ -28,7 +27,7 @@ public partial class CreateIncidentViewModel : BaseViewModel
     [ObservableProperty]
     private bool isLoadingSensors;
 
-    public CreateIncidentViewModel(IIncidentApiService incidentService, SensorApiService sensorService, ITokenProvider tokenProvider)
+    public CreateIncidentViewModel(IIncidentApiService incidentService, ISensorApiService sensorService, ITokenProvider tokenProvider)
     {
         _incidentService = incidentService;
         _sensorService = sensorService;

--- a/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/CreateIncidentViewModel.cs
@@ -5,6 +5,7 @@ using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Dtos;
 using System.Collections.ObjectModel;
 using SensorApp.Shared.Models;
+using SensorApp.Shared.Enums;
 
 namespace SensorApp.Maui.ViewModels;
 
@@ -20,14 +21,14 @@ public partial class CreateIncidentViewModel : BaseViewModel
     private readonly ITokenProvider _tokenProvider;
 
     [ObservableProperty] private SensorModel selectedSensor;
-    [ObservableProperty] private string selectedType;
+    [ObservableProperty] private IncidentType selectedType;
     [ObservableProperty] private int selectedSensorId;
-    [ObservableProperty] private string selectedPriority;
+    [ObservableProperty] private IncidentPriority selectedPriority;
 
     [ObservableProperty] private string comments;
 
-    public List<string> TypeOptions { get; } = ["Max threshold breach", "Min threshold breach", "Sensor unresponsive"];
-    public List<string> PriorityOptions { get; } = ["High", "Medium", "Low"];
+    public List<IncidentType> TypeOptions { get; } = Enum.GetValues<IncidentType>().ToList();
+    public List<IncidentPriority> PriorityOptions { get; } = Enum.GetValues<IncidentPriority>().ToList();
 
     public ObservableCollection<SensorModel> Sensors { get; } = new();
 
@@ -111,7 +112,7 @@ public partial class CreateIncidentViewModel : BaseViewModel
             var newIncident = new CreateIncidentDto
             {
                 Type = SelectedType,
-                Status = "Open",
+                Status = IncidentStatus.Open,
                 SensorId = SelectedSensorId,
                 Priority = SelectedPriority,
                 Comments = Comments,

--- a/SensorApp/SensorApp.Maui/ViewModels/HistoricalDataViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/HistoricalDataViewModel.cs
@@ -15,10 +15,10 @@ public partial class HistoricalDataViewModel : BaseViewModel
     readonly IMeasurementService _measurementService;
     readonly ITokenProvider _tokenProvider;
     readonly IMeasurandService _measurandService;
-    readonly SensorApiService _sensorService;
+    readonly ISensorApiService _sensorService;
     readonly IChartFactory _chartFactory;
 
-    public HistoricalDataViewModel(IMeasurementService measurementService, ITokenProvider tokenProvider, SensorApiService sensorService, IMeasurandService measurandService, IChartFactory chartFactory)
+    public HistoricalDataViewModel(IMeasurementService measurementService, ITokenProvider tokenProvider, ISensorApiService sensorService, IMeasurandService measurandService, IChartFactory chartFactory)
     {
         _measurementService = measurementService;
         _tokenProvider = tokenProvider;

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -1,0 +1,16 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using SensorApp.Shared.Dtos.Incident;
+
+namespace SensorApp.Maui.ViewModels;
+
+[QueryProperty(nameof(Incident), "Incident")]
+public partial class IncidentDetailViewModel : BaseViewModel
+{
+    [ObservableProperty]
+    private IncidentDto incident;
+
+    public void LoadIncident(IncidentDto selectedIncident)
+    {
+        Incident = selectedIncident;
+    }
+}

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -2,7 +2,6 @@
 using CommunityToolkit.Mvvm.Input;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Interfaces;
-using static AndroidX.Concurrent.Futures.CallbackToFutureAdapter;
 
 namespace SensorApp.Maui.ViewModels;
 
@@ -19,7 +18,6 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
     private string resolutionComments;
 
     public bool IsOpen => Incident?.Status != "Resolved";
-
 
     public void LoadIncident(IncidentDto selectedIncident)
     {

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.Input;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Interfaces;
+using static AndroidX.Concurrent.Futures.CallbackToFutureAdapter;
 
 namespace SensorApp.Maui.ViewModels;
 
@@ -17,9 +18,16 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
     [ObservableProperty]
     private string resolutionComments;
 
+    public bool IsOpen => Incident?.Status != "Resolved";
+
+
     public void LoadIncident(IncidentDto selectedIncident)
     {
         Incident = selectedIncident;
+    }
+    partial void OnIncidentChanged(IncidentDto value)
+    {
+        OnPropertyChanged(nameof(IsOpen));
     }
 
     [RelayCommand]
@@ -36,6 +44,8 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
             var success = await _incidentService.ResolveIncidentAsync(token, Incident.Id, dto);
             if (success)
             {
+                Incident.Status = "Resolved";
+                OnPropertyChanged(nameof(IsOpen));
                 await Shell.Current.DisplayAlert("Success", "Incident resolved.", "OK");
                 await Shell.Current.GoToAsync("..");
             }

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Enums;
 using SensorApp.Shared.Interfaces;
 
 namespace SensorApp.Maui.ViewModels;
@@ -21,7 +22,7 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
     [ObservableProperty]
     private string resolutionComments;
 
-    public bool IsOpen => Incident?.Status != "Resolved";
+    public bool IsOpen => Incident?.Status != IncidentStatus.Resolved;
 
     /// <summary>
     /// Method to load the details of a selected incident into the ViewModel.
@@ -60,8 +61,10 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
             var success = await _incidentService.ResolveIncidentAsync(token, Incident.Id, dto);
             if (success)
             {
-                Incident.Status = "Resolved";
+                Incident.Status = IncidentStatus.Resolved;
+                Incident.Resolution_comments = resolutionComments;
                 OnPropertyChanged(nameof(IsOpen));
+                OnPropertyChanged(nameof(Incident));
                 await Shell.Current.DisplayAlert("Success", "Incident resolved.", "OK");
                 await Shell.Current.GoToAsync("..");
             }

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -49,4 +49,33 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
             await Shell.Current.DisplayAlert("Error", "Something went wrong.", "OK");
         }
     }
+
+    [RelayCommand]
+    public async Task DeleteIncidentAsync()
+    {
+        bool confirm = await Shell.Current.DisplayAlert("Confirm", "Are you sure you want to delete this incident?", "Yes", "No");
+        if (!confirm)
+            return;
+
+        try
+        {
+            var token = await _tokenProvider.GetTokenAsync();
+            var success = await _incidentService.DeleteIncidentAsync(token, Incident.Id);
+
+            if (success)
+            {
+                await Shell.Current.DisplayAlert("Deleted", "Incident deleted successfully.", "OK");
+                await Shell.Current.GoToAsync("..");
+            }
+            else
+            {
+                await Shell.Current.DisplayAlert("Error", "Failed to delete incident.", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            await Shell.Current.DisplayAlert("Error", "An unexpected error occurred.", "OK");
+        }
+    }
+
 }

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -5,6 +5,10 @@ using SensorApp.Shared.Interfaces;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for managing the detail of a specific incident. 
+/// This handles the logic for resolving or deleting an incident and updating the UI accordingly.
+/// </summary>
 [QueryProperty(nameof(Incident), "Incident")]
 public partial class IncidentDetailViewModel(IIncidentApiService incidentService, ITokenProvider tokenProvider) : BaseViewModel
 {
@@ -19,15 +23,29 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
 
     public bool IsOpen => Incident?.Status != "Resolved";
 
+    /// <summary>
+    /// Method to load the details of a selected incident into the ViewModel.
+    /// </summary>
+    /// <param name="selectedIncident">The incident to load into the ViewModel.</param>
     public void LoadIncident(IncidentDto selectedIncident)
     {
         Incident = selectedIncident;
     }
+
+    /// <summary>
+    /// This partial method is called whenever the incident property changes.
+    /// It updates the IsOpen property to reflect the current status of the incident.
+    /// </summary>
+    /// <param name="value">The updated incident.</param>
     partial void OnIncidentChanged(IncidentDto value)
     {
         OnPropertyChanged(nameof(IsOpen));
     }
 
+    /// <summary>
+    /// Command for resolving an incident. It calls the API to resolve the incident
+    /// and updates the incident's status to "Resolved".
+    /// </summary>
     [RelayCommand]
     public async Task ResolveIncidentAsync()
     {
@@ -58,6 +76,9 @@ public partial class IncidentDetailViewModel(IIncidentApiService incidentService
         }
     }
 
+    /// <summary>
+    /// Command for deleting an incident. It confirms the deletion and calls the API to delete the incident.
+    /// </summary>
     [RelayCommand]
     public async Task DeleteIncidentAsync()
     {

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentDetailViewModel.cs
@@ -1,16 +1,52 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Interfaces;
 
 namespace SensorApp.Maui.ViewModels;
 
 [QueryProperty(nameof(Incident), "Incident")]
-public partial class IncidentDetailViewModel : BaseViewModel
+public partial class IncidentDetailViewModel(IIncidentApiService incidentService, ITokenProvider tokenProvider) : BaseViewModel
 {
+    private readonly ITokenProvider _tokenProvider = tokenProvider;
+    private readonly IIncidentApiService _incidentService = incidentService;
+
     [ObservableProperty]
     private IncidentDto incident;
+
+    [ObservableProperty]
+    private string resolutionComments;
 
     public void LoadIncident(IncidentDto selectedIncident)
     {
         Incident = selectedIncident;
+    }
+
+    [RelayCommand]
+    public async Task ResolveIncidentAsync()
+    {
+        try
+        {
+            var token = await _tokenProvider.GetTokenAsync();
+            var dto = new IncidentResolutionDto
+            {
+                ResolutionComments = resolutionComments
+            };
+
+            var success = await _incidentService.ResolveIncidentAsync(token, Incident.Id, dto);
+            if (success)
+            {
+                await Shell.Current.DisplayAlert("Success", "Incident resolved.", "OK");
+                await Shell.Current.GoToAsync("..");
+            }
+            else
+            {
+                await Shell.Current.DisplayAlert("Error", "Failed to resolve incident.", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            await Shell.Current.DisplayAlert("Error", "Something went wrong.", "OK");
+        }
     }
 }

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
@@ -30,6 +30,7 @@ public partial class IncidentListViewModel(IIncidentApiService incidentService, 
             }
 
             var list = await _incidentService.GetAllIncidentsAsync(token);
+            incidents.Clear();
             foreach (var incident in list)
             {
                 incidents.Add(incident);

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
@@ -9,6 +9,10 @@ using SensorApp.Maui.Views.Pages;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for managing a viewable list of sensor incidents.
+/// Handles loading the list of incidents from the API, navigation to create new incidents and details pages.
+/// </summary>
 public partial class IncidentListViewModel(IIncidentApiService incidentService, ITokenProvider tokenProvider) : BaseViewModel
 {
     private readonly ITokenProvider _tokenProvider = tokenProvider;
@@ -42,12 +46,19 @@ public partial class IncidentListViewModel(IIncidentApiService incidentService, 
         }
     }
 
+    /// <summary>
+    /// Command to navigate to the Create Incident page.
+    /// </summary>
     [RelayCommand]
     public async Task GoToCreateIncident()
     {
         await Shell.Current.GoToAsync(nameof(CreateIncidentPage));
     }
 
+    /// <summary>
+    /// Command to navigate to the Incident Detail page for the selected incident.
+    /// </summary>
+    /// <param name="selected">The incident that was selected for viewing.</param>
     [RelayCommand]
     public async Task GoToIncidentDetailsAsync(IncidentDto selected)
     {

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Services;
 using SensorApp.Shared.Interfaces;
+using SensorApp.Maui.Views.Pages;
 
 namespace SensorApp.Maui.ViewModels;
 
@@ -38,5 +39,11 @@ public partial class IncidentListViewModel(IIncidentApiService incidentService, 
         {
             await Shell.Current.DisplayAlert("Error", "Unable to load incidents.", "OK");
         }
+    }
+
+    [RelayCommand]
+    public async Task GoToCreateIncident()
+    {
+        await Shell.Current.GoToAsync(nameof(CreateIncidentPage));
     }
 }

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
@@ -1,0 +1,42 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Services;
+using SensorApp.Shared.Interfaces;
+
+namespace SensorApp.Maui.ViewModels;
+
+public partial class IncidentListViewModel(IIncidentApiService incidentService, ITokenProvider tokenProvider) : BaseViewModel
+{
+    private readonly ITokenProvider _tokenProvider = tokenProvider;
+    private readonly IIncidentApiService _incidentService = incidentService;
+
+    [ObservableProperty]
+    private ObservableCollection<IncidentDto> incidents = new();
+
+    [RelayCommand]
+    public async Task LoadIncidentsAsync()
+    {
+        try
+        {
+            var token = await _tokenProvider.GetTokenAsync();
+            if (string.IsNullOrEmpty(token))
+            {
+                await Shell.Current.DisplayAlert("Error", "You are not logged in or your session has expired. Please log in again.", "OK");
+                return;
+            }
+
+            var list = await _incidentService.GetAllIncidentsAsync(token);
+            foreach (var incident in list)
+            {
+                incidents.Add(incident);
+            }
+        }
+        catch (Exception ex)
+        {
+            await Shell.Current.DisplayAlert("Error", "Unable to load incidents.", "OK");
+        }
+    }
+}

--- a/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/IncidentListViewModel.cs
@@ -47,4 +47,19 @@ public partial class IncidentListViewModel(IIncidentApiService incidentService, 
     {
         await Shell.Current.GoToAsync(nameof(CreateIncidentPage));
     }
+
+    [RelayCommand]
+    public async Task GoToIncidentDetailsAsync(IncidentDto selected)
+    {
+        if (selected == null)
+            return;
+
+        var navParam = new Dictionary<string, object>
+        {
+            { "Incident", selected }
+        };
+
+        await Shell.Current.GoToAsync(nameof(IncidentDetailPage), navParam);
+    }
+
 }

--- a/SensorApp/SensorApp.Maui/ViewModels/SensorMapViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/SensorMapViewModel.cs
@@ -14,7 +14,7 @@ namespace SensorApp.Maui.ViewModels;
 /// </summary>
 public partial class SensorMapViewModel : BaseViewModel
 {
-    private readonly SensorApiService _sensorService;
+    private readonly ISensorApiService _sensorService;
     private readonly ISensorPinInfoFactory pinInfoFactory;
     private readonly ISensorAnalysisService _sensorAnalysisService;
 
@@ -40,7 +40,7 @@ public partial class SensorMapViewModel : BaseViewModel
     /// <param name="sensorService">The service for retrieving sensor data.</param>
     /// <param name="pinInfoFactory">Factory for creating sensor pin information.</param>
     /// <param name="sensorAnalysisService">Service for analyzing sensor data.</param>
-    public SensorMapViewModel(SensorApiService _sensorService, ISensorPinInfoFactory pinInfoFactory, ISensorAnalysisService _sensorAnalysisService)
+    public SensorMapViewModel(ISensorApiService _sensorService, ISensorPinInfoFactory pinInfoFactory, ISensorAnalysisService _sensorAnalysisService)
     {
         this._sensorService = _sensorService;
         this.pinInfoFactory = pinInfoFactory;

--- a/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewmodel="clr-namespace:SensorApp.Maui.ViewModels"
+    x:Class="SensorApp.Maui.Views.Pages.CreateIncidentPage"
+    x:DataType="viewmodel:CreateIncidentViewModel"
+    Title="Create new incident report">
+
+    <ScrollView>
+        <VerticalStackLayout Spacing="15" Padding="20">
+
+            <VerticalStackLayout Padding="20" Spacing="10">
+                <Label Text="Incident Type" />
+                <Picker ItemsSource="{Binding TypeOptions}"
+                SelectedItem="{Binding SelectedType}" />
+
+                <Label Text="Sensor" />
+                <Picker ItemsSource="{Binding Sensors}"
+                 SelectedItem="{Binding SelectedSensor}"
+                 ItemDisplayBinding="{Binding Id}" />
+                
+                <Label Text="Priority" />
+                <Picker ItemsSource="{Binding PriorityOptions}"
+                SelectedItem="{Binding SelectedPriority}" />
+
+                <Label Text="Comments" />
+                <Editor Text="{Binding Comments}" AutoSize="TextChanges" />
+
+                <Button Text="Submit" Command="{Binding CreateIncidentCommand}" />
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
@@ -16,7 +16,8 @@
             <VerticalStackLayout Padding="20" Spacing="10" IsVisible="{Binding IsLoadingSensors, Converter={StaticResource InverseBoolConverter}}">
                 <Label Text="Incident Type" />
                 <Picker ItemsSource="{Binding TypeOptions}"
-                SelectedItem="{Binding SelectedType}" />
+                SelectedItem="{Binding SelectedType}" 
+                ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDisplayName}}"/>
 
                 <Label Text="Sensor" />
                 <Picker ItemsSource="{Binding Sensors}"
@@ -25,7 +26,8 @@
                 
                 <Label Text="Priority" />
                 <Picker ItemsSource="{Binding PriorityOptions}"
-                SelectedItem="{Binding SelectedPriority}" />
+                SelectedItem="{Binding SelectedPriority}"
+                ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDisplayName}}"/>
 
                 <Label Text="Comments" />
                 <Editor Text="{Binding Comments}" AutoSize="TextChanges" />

--- a/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml
@@ -10,7 +10,10 @@
     <ScrollView>
         <VerticalStackLayout Spacing="15" Padding="20">
 
-            <VerticalStackLayout Padding="20" Spacing="10">
+            <ActivityIndicator IsRunning="{Binding IsLoadingSensors}" 
+                   IsVisible="{Binding IsLoadingSensors}"/>
+
+            <VerticalStackLayout Padding="20" Spacing="10" IsVisible="{Binding IsLoadingSensors, Converter={StaticResource InverseBoolConverter}}">
                 <Label Text="Incident Type" />
                 <Picker ItemsSource="{Binding TypeOptions}"
                 SelectedItem="{Binding SelectedType}" />

--- a/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml.cs
@@ -1,0 +1,12 @@
+using SensorApp.Maui.ViewModels;
+
+namespace SensorApp.Maui.Views.Pages;
+
+public partial class CreateIncidentPage : ContentPage
+{
+    public CreateIncidentPage(CreateIncidentViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}

--- a/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/CreateIncidentPage.xaml.cs
@@ -2,8 +2,17 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Represents the page where a user can create a new incident.
+/// The page is bound to the CreateIncidentViewModel which handles the logic of creating incidents.
+/// </summary>
 public partial class CreateIncidentPage : ContentPage
 {
+    /// <summary>
+    /// Constructor for initializing the CreateIncidentPage.
+    /// The page's BindingContext is set to the provided CreateIncidentViewModel.
+    /// </summary>
+    /// <param name="vm">The ViewModel that contains the logic for creating incidents.</param>
     public CreateIncidentPage(CreateIncidentViewModel vm)
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -28,10 +28,19 @@
             <Label Text="Resolution Comments" />
             <Editor Text="{Binding Incident.Resolution_comments}" AutoSize="TextChanges" />
 
-            <Button Text="Resolve Incident"
-            Command="{Binding ResolveIncidentCommand}"
-            BackgroundColor="Indigo"
-            TextColor="White" />
+            <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
+                <Button Text="Resolve Incident"
+                Command="{Binding ResolveIncidentCommand}"
+                BackgroundColor="Indigo"
+                TextColor="White"
+                WidthRequest="150" />
+
+                <Button Text="Delete Incident"
+                Command="{Binding DeleteIncidentCommand}"
+                BackgroundColor="DarkRed"
+                TextColor="White"
+                WidthRequest="150" />
+            </HorizontalStackLayout>
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -24,6 +24,14 @@
             <Label Text="{Binding Incident.Responder_id}" />
             <Label Text="Comments:" FontSize="Medium" FontAttributes="Bold" />
             <Label Text="{Binding Incident.Comments}" />
+
+            <Label Text="Resolution Comments" />
+            <Editor Text="{Binding Incident.Resolution_comments}" AutoSize="TextChanges" />
+
+            <Button Text="Resolve Incident"
+            Command="{Binding ResolveIncidentCommand}"
+            BackgroundColor="Indigo"
+            TextColor="White" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -3,30 +3,76 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:viewmodel="clr-namespace:SensorApp.Maui.ViewModels"
     x:Class="SensorApp.Maui.Views.Pages.IncidentDetailPage"
+    
     x:DataType="viewmodel:IncidentDetailViewModel"
     Title="Incident Details">
 
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="15">
-            <Label Text="Incident Type:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Type}" />
-            <Label Text="Status:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Status}" />
-            <Label Text="Date created:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Creation_date}" />
-            <Label Text="Sensor type:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Sensor.Type}" />
-            <Label Text="Location:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Sensor.Site_zone}" />
-            <Label Text="Priority:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Priority}" />
-            <Label Text="Incident reported by:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Responder_id}" />
-            <Label Text="Comments:" FontSize="Medium" FontAttributes="Bold" />
-            <Label Text="{Binding Incident.Comments}" />
+            <VerticalStackLayout>
+                <Label Text="Incident Type:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Type}" />
+            </VerticalStackLayout>
 
-            <Label Text="Resolution Comments" />
-            <Editor Text="{Binding Incident.Resolution_comments}" AutoSize="TextChanges" />
+            <VerticalStackLayout>
+                <Label Text="Status:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Status}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Date created:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Creation_date}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Sensor type:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Sensor.Type}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Location:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Sensor.Site_zone}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Priority:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Priority}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Incident reported by:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Responder.Username}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Comments:" FontSize="Medium" FontAttributes="Bold" />
+                <Label Text="{Binding Incident.Comments, Converter={StaticResource NullToPlaceholderConverter}}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout>
+                <Label Text="Resolution Comments" FontSize="Medium" FontAttributes="Bold" />
+
+                <Editor Text="{Binding ResolutionComments}" AutoSize="TextChanges">
+                    <Editor.Triggers>
+                        <DataTrigger TargetType="Editor"
+                         Binding="{Binding IsOpen}"
+                         Value="False">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </Editor.Triggers>
+                </Editor>
+
+                <Label Text="{Binding Incident.Resolution_comments, Converter={StaticResource NullToPlaceholderConverter}}">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label"
+                         Binding="{Binding IsOpen}"
+                         Value="True">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+            </VerticalStackLayout>
+
 
             <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
                 <Button Text="Resolve Incident"

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -1,0 +1,29 @@
+<ContentPage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewmodel="clr-namespace:SensorApp.Maui.ViewModels"
+    x:Class="SensorApp.Maui.Views.Pages.IncidentDetailPage"
+    x:DataType="viewmodel:IncidentDetailViewModel"
+    Title="Incident Details">
+
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="15">
+            <Label Text="Incident Type:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Type}" />
+            <Label Text="Status:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Status}" />
+            <Label Text="Date created:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Creation_date}" />
+            <Label Text="Sensor type:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Sensor.Type}" />
+            <Label Text="Location:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Sensor.Site_zone}" />
+            <Label Text="Priority:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Priority}" />
+            <Label Text="Incident reported by:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Responder_id}" />
+            <Label Text="Comments:" FontSize="Medium" FontAttributes="Bold" />
+            <Label Text="{Binding Incident.Comments}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -33,7 +33,8 @@
                 Command="{Binding ResolveIncidentCommand}"
                 BackgroundColor="Indigo"
                 TextColor="White"
-                WidthRequest="150" />
+                WidthRequest="150" 
+                IsVisible="{Binding IsOpen}"/>
 
                 <Button Text="Delete Incident"
                 Command="{Binding DeleteIncidentCommand}"

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml
@@ -11,7 +11,7 @@
         <VerticalStackLayout Padding="20" Spacing="15">
             <VerticalStackLayout>
                 <Label Text="Incident Type:" FontSize="Medium" FontAttributes="Bold" />
-                <Label Text="{Binding Incident.Type}" />
+                <Label Text="{Binding Incident.Type, Converter={StaticResource EnumDisplayName}}" />
             </VerticalStackLayout>
 
             <VerticalStackLayout>
@@ -36,7 +36,7 @@
 
             <VerticalStackLayout>
                 <Label Text="Priority:" FontSize="Medium" FontAttributes="Bold" />
-                <Label Text="{Binding Incident.Priority}" />
+                <Label Text="{Binding Incident.Priority, Converter={StaticResource EnumDisplayName}}" />
             </VerticalStackLayout>
 
             <VerticalStackLayout>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml.cs
@@ -2,8 +2,17 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Represents the page that displays the details of a selected incident.
+/// The page is bound to the IncidentDetailViewModel which handles the logic of incident details.
+/// </summary>
 public partial class IncidentDetailPage : ContentPage
 {
+    /// <summary>
+    /// Constructor for initializing the IncidentDetailPage.
+    /// The page's BindingContext is set to the provided IncidentDetailViewModel.
+    /// </summary>
+    /// <param name="vm">The ViewModel that contains the logic for displaying incident details.</param>
 	public IncidentDetailPage(IncidentDetailViewModel vm)
 	{
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentDetailPage.xaml.cs
@@ -1,0 +1,12 @@
+using SensorApp.Maui.ViewModels;
+
+namespace SensorApp.Maui.Views.Pages;
+
+public partial class IncidentDetailPage : ContentPage
+{
+	public IncidentDetailPage(IncidentDetailViewModel vm)
+	{
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -14,7 +14,7 @@
             <Button Text="Create new incident report" BackgroundColor="Green" TextColor="White" Command="{Binding GoToCreateIncidentCommand}" />
         </VerticalStackLayout>
 
-        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}" SelectionMode="Single" SelectionChanged="OnIncidentSelected">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:IncidentDto">
                     <Frame Padding="12" Margin="0,6" BorderColor="LightGray" CornerRadius="8" HasShadow="False">

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodel="clr-namespace:SensorApp.Maui.ViewModels"
              x:Class="SensorApp.Maui.Views.Pages.IncidentList"
-             xmlns:models="clr-namespace:SensorApp.Shared.Models;assembly=SensorApp.Shared"
+             xmlns:models="clr-namespace:SensorApp.Shared.Dtos.Incident;assembly=SensorApp.Shared"
              x:DataType="viewmodel:IncidentListViewModel"
              x:Name="RootPage"
              Title="Operations manager: Incident list">
@@ -12,14 +12,14 @@
 
         <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
             <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="models:Incident">
+                <DataTemplate x:DataType="models:IncidentDto">
                     <Frame Padding="12" Margin="0,6" BorderColor="LightGray" CornerRadius="8" HasShadow="False">
 
                         <Grid ColumnDefinitions="*,Auto">
 
                             <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
 
-                                <Label Text="{Binding Comments, TargetNullValue='No Comments'}" FontAttributes="Bold" FontSize="16" />
+                                <Label Text="{Binding ., Converter={StaticResource IncidentLabelConverter}}" FontAttributes="Bold" FontSize="16" />
 
                             </VerticalStackLayout>
 

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -6,7 +6,7 @@
              xmlns:models="clr-namespace:SensorApp.Shared.Dtos.Incident;assembly=SensorApp.Shared"
              x:DataType="viewmodel:IncidentListViewModel"
              x:Name="RootPage"
-             Title="Operations manager: Incident list">
+             Title="Incident report list">
 
     <Grid RowDefinitions="Auto,*" Padding="10">
 
@@ -14,7 +14,7 @@
             <Button Text="Create new incident report" BackgroundColor="Green" TextColor="White" Command="{Binding GoToCreateIncidentCommand}" />
         </VerticalStackLayout>
 
-        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}" >
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:IncidentDto">
                     <Frame Padding="12" Margin="0,6" BorderColor="LightGray" CornerRadius="8" HasShadow="False">
@@ -30,8 +30,7 @@
                                 <HorizontalStackLayout Spacing="8">
                                     <Label Text="{Binding Status}" FontSize="14" />
                                 </HorizontalStackLayout>
-                                
-                                
+
                             </VerticalStackLayout>
 
                         </Grid>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodel="clr-namespace:SensorApp.Maui.ViewModels"
+             x:Class="SensorApp.Maui.Views.Pages.IncidentList"
+             xmlns:models="clr-namespace:SensorApp.Shared.Models;assembly=SensorApp.Shared"
+             x:DataType="viewmodel:IncidentListViewModel"
+             x:Name="RootPage"
+             Title="Operations manager: Incident list">
+
+    <Grid RowDefinitions="Auto,*" Padding="10">
+
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:Incident">
+                    <Frame Padding="12" Margin="0,6" BorderColor="LightGray" CornerRadius="8" HasShadow="False">
+
+                        <Grid ColumnDefinitions="*,Auto">
+
+                            <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
+
+                                <Label Text="{Binding Comments, TargetNullValue='No Comments'}" FontAttributes="Bold" FontSize="16" />
+
+                            </VerticalStackLayout>
+
+                        </Grid>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+
+</ContentPage>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -19,8 +19,11 @@
 
                             <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
 
-                                <Label Text="{Binding ., Converter={StaticResource IncidentLabelConverter}}" FontAttributes="Bold" FontSize="16" />
-
+                                <Label Text="{Binding ., Converter={StaticResource IncidentLabelConverter}}" FontAttributes="Bold" FontSize="18" />
+                                <HorizontalStackLayout Spacing="8">
+                                    <Label Text="{Binding Status}" FontSize="14" />
+                                </HorizontalStackLayout>
+                                
                             </VerticalStackLayout>
 
                         </Grid>

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -10,6 +10,10 @@
 
     <Grid RowDefinitions="Auto,*" Padding="10">
 
+        <VerticalStackLayout Spacing="10" Grid.Row="0">
+            <Button Text="Create new incident report" BackgroundColor="Green" TextColor="White" Command="{Binding GoToCreateIncidentCommand}" />
+        </VerticalStackLayout>
+
         <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:IncidentDto">

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml
@@ -14,11 +14,14 @@
             <Button Text="Create new incident report" BackgroundColor="Green" TextColor="White" Command="{Binding GoToCreateIncidentCommand}" />
         </VerticalStackLayout>
 
-        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}" SelectionMode="Single" SelectionChanged="OnIncidentSelected">
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Incidents}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:IncidentDto">
                     <Frame Padding="12" Margin="0,6" BorderColor="LightGray" CornerRadius="8" HasShadow="False">
-
+                        <Frame.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Source={x:Reference RootPage}, Path=BindingContext.GoToIncidentDetailsCommand}" CommandParameter="{Binding .}" />
+                        </Frame.GestureRecognizers>
+                        
                         <Grid ColumnDefinitions="*,Auto">
 
                             <VerticalStackLayout Grid.Column="0" Spacing="4" VerticalOptions="Center">
@@ -27,6 +30,7 @@
                                 <HorizontalStackLayout Spacing="8">
                                     <Label Text="{Binding Status}" FontSize="14" />
                                 </HorizontalStackLayout>
+                                
                                 
                             </VerticalStackLayout>
 

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -1,0 +1,19 @@
+using SensorApp.Maui.ViewModels;
+
+namespace SensorApp.Maui.Views.Pages;
+
+public partial class IncidentList : ContentPage
+{
+    private readonly IncidentListViewModel _viewModel;
+    public IncidentList(IncidentListViewModel vm)
+	{
+		InitializeComponent();
+        _viewModel = vm;
+        BindingContext = _viewModel;
+    }
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadIncidentsAsync();
+    }
+}

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -18,13 +18,4 @@ public partial class IncidentList : ContentPage
         base.OnAppearing();
         await _viewModel.LoadIncidentsAsync();
     }
-
-    private async void OnIncidentSelected(object sender, SelectionChangedEventArgs e)
-    {
-        if (e.CurrentSelection.FirstOrDefault() is IncidentDto selectedIncident)
-        {
-            await _viewModel.GoToIncidentDetailsAsync(selectedIncident);
-        }
-    }
-
 }

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -4,15 +4,29 @@ using SensorApp.Shared.Dtos.Incident;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Represents the page that displays a list of incidents.
+/// The page is bound to the IncidentListViewModel which handles the logic of loading and managing incidents.
+/// </summary>
 public partial class IncidentList : ContentPage
 {
     private readonly IncidentListViewModel _viewModel;
+
+    /// <summary>
+    /// Constructor for initializing the IncidentList page.
+    /// Sets up the BindingContext to the provided IncidentListViewModel.
+    /// </summary>
+    /// <param name="vm">The ViewModel responsible for managing incidents.</param>
     public IncidentList(IncidentListViewModel vm)
 	{
 		InitializeComponent();
         _viewModel = vm;
         BindingContext = _viewModel;
     }
+
+    /// <summary>
+    /// This method is called when the page appears. It triggers the loading of incidents from the ViewModel.
+    /// </summary>
     protected override async void OnAppearing()
     {
         base.OnAppearing();

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -17,5 +17,5 @@ public partial class IncidentList : ContentPage
     {
         base.OnAppearing();
         await _viewModel.LoadIncidentsAsync();
-    }
+    }   
 }

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.Input;
 using SensorApp.Maui.ViewModels;
+using SensorApp.Shared.Dtos.Incident;
 
 namespace SensorApp.Maui.Views.Pages;
 
@@ -17,4 +18,13 @@ public partial class IncidentList : ContentPage
         base.OnAppearing();
         await _viewModel.LoadIncidentsAsync();
     }
+
+    private async void OnIncidentSelected(object sender, SelectionChangedEventArgs e)
+    {
+        if (e.CurrentSelection.FirstOrDefault() is IncidentDto selectedIncident)
+        {
+            await _viewModel.GoToIncidentDetailsAsync(selectedIncident);
+        }
+    }
+
 }

--- a/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/IncidentList.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Input;
 using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;

--- a/SensorApp/SensorApp.Maui/Views/Pages/SensorMapPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/SensorMapPage.xaml.cs
@@ -21,7 +21,7 @@ public partial class SensorMapPage : ContentPage
     /// <param name="sensorService">Service for fetching sensor data.</param>
     /// <param name="pinInfoFactory">Factory for creating sensor pin information.</param>
     /// <param name="sensorAnalysisService">Service for analyzing sensor data.</param>
-    public SensorMapPage(SensorApiService _sensorService, ISensorPinInfoFactory pinInfoFactory, ISensorAnalysisService _sensorAnalysisService)
+    public SensorMapPage(ISensorApiService _sensorService, ISensorPinInfoFactory pinInfoFactory, ISensorAnalysisService _sensorAnalysisService)
     {
         InitializeComponent();
         this._sensorAnalysisService = _sensorAnalysisService;

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using SensorApp.Shared.Dtos.Admin;
+
+namespace SensorApp.Shared.Dtos.Incident;
+
+public class CreateIncidentDto
+{
+    public string Type { get; set; }
+    public string Status { get; set; }
+    public int SensorId { get; set; }
+    public string Priority { get; set; }
+    public string? Comments { get; set; }
+}

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
@@ -11,7 +11,7 @@ public class CreateIncidentDto
 {
     public required string Type { get; set; }
     public required string Status { get; set; }
-    public required int SensorId { get; set; }
+    public int SensorId { get; set; }
     public required string Priority { get; set; }
     public string? Comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
@@ -3,11 +3,15 @@ using SensorApp.Shared.Dtos.Admin;
 
 namespace SensorApp.Shared.Dtos.Incident;
 
+/// <summary>
+/// Data Transfer Object (DTO) used for creating a new incident.
+/// This DTO contains all the necessary information to create an incident in the system.
+/// </summary>
 public class CreateIncidentDto
 {
-    public string Type { get; set; }
-    public string Status { get; set; }
-    public int SensorId { get; set; }
-    public string Priority { get; set; }
+    public required string Type { get; set; }
+    public required string Status { get; set; }
+    public required int SensorId { get; set; }
+    public required string Priority { get; set; }
     public string? Comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/CreateIncidentDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SensorApp.Shared.Dtos.Admin;
+using SensorApp.Shared.Enums;
 
 namespace SensorApp.Shared.Dtos.Incident;
 
@@ -9,9 +10,9 @@ namespace SensorApp.Shared.Dtos.Incident;
 /// </summary>
 public class CreateIncidentDto
 {
-    public required string Type { get; set; }
-    public required string Status { get; set; }
+    public required IncidentType Type { get; set; }
+    public required IncidentStatus Status { get; set; }
     public int SensorId { get; set; }
-    public required string Priority { get; set; }
+    public required IncidentPriority Priority { get; set; }
     public string? Comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
@@ -8,13 +8,13 @@ public class IncidentDto
     public required int Id { get; set; }
     public required string Type { get; set; }
     public required string Status { get; set; }
-    public required SensorDto Sensor { get; set; }
+    public SensorDto Sensor { get; set; }
     public required int Sensor_id { get; set; }
     public required DateTime Creation_date { get; set; }
     public required string Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
-    public required string Responder_id { get; set; }
-    public required UserWithRoleDto Responder { get; set; }
+    public string Responder_id { get; set; }
+    public UserWithRoleDto Responder { get; set; }
     public string? Comments { get; set; }
     public string? Resolution_comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using SensorApp.Shared.Dtos.Admin;
+
+namespace SensorApp.Shared.Dtos.Incident;
+
+public class IncidentDto
+{
+    public int Id { get; set; }
+    public string Type { get; set; }
+    public string Status { get; set; }
+    public SensorDto Sensor { get; set; }
+    public int Sensor_id { get; set; }
+    public DateTime Creation_date { get; set; }
+    public string Priority { get; set; }
+    public DateTime? Resolution_date { get; set; }
+    public string Responder_id { get; set; }
+    public UserWithRoleDto Responder { get; set; }
+    public string? Comments { get; set; }
+}

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
@@ -16,4 +16,5 @@ public class IncidentDto
     public string Responder_id { get; set; }
     public UserWithRoleDto Responder { get; set; }
     public string? Comments { get; set; }
+    public string? Resolution_comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
@@ -1,4 +1,5 @@
 ﻿using SensorApp.Shared.Dtos.Admin;
+using SensorApp.Shared.Enums;
 
 namespace SensorApp.Shared.Dtos.Incident;
 
@@ -6,12 +7,12 @@ namespace SensorApp.Shared.Dtos.Incident;
 public class IncidentDto
 {
     public required int Id { get; set; }
-    public required string Type { get; set; }
-    public required string Status { get; set; }
+    public required IncidentType Type { get; set; }
+    public required IncidentStatus Status { get; set; }
     public SensorDto Sensor { get; set; }
     public required int Sensor_id { get; set; }
     public required DateTime Creation_date { get; set; }
-    public required string Priority { get; set; }
+    public required IncidentPriority Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
     public string Responder_id { get; set; }
     public UserWithRoleDto Responder { get; set; }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentDto.cs
@@ -1,20 +1,20 @@
-﻿using System;
-using SensorApp.Shared.Dtos.Admin;
+﻿using SensorApp.Shared.Dtos.Admin;
 
 namespace SensorApp.Shared.Dtos.Incident;
 
+
 public class IncidentDto
 {
-    public int Id { get; set; }
-    public string Type { get; set; }
-    public string Status { get; set; }
-    public SensorDto Sensor { get; set; }
-    public int Sensor_id { get; set; }
-    public DateTime Creation_date { get; set; }
-    public string Priority { get; set; }
+    public required int Id { get; set; }
+    public required string Type { get; set; }
+    public required string Status { get; set; }
+    public required SensorDto Sensor { get; set; }
+    public required int Sensor_id { get; set; }
+    public required DateTime Creation_date { get; set; }
+    public required string Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
-    public string Responder_id { get; set; }
-    public UserWithRoleDto Responder { get; set; }
+    public required string Responder_id { get; set; }
+    public required UserWithRoleDto Responder { get; set; }
     public string? Comments { get; set; }
     public string? Resolution_comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SensorApp.Shared.Dtos.Incident
+{
+    public class IncidentResolutionDto
+    {
+        public string ResolutionComments { get; set; }
+        public DateTime ResolutionDate { get; set; }
+    }
+
+}

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace SensorApp.Shared.Dtos.Incident
-{
-    public class IncidentResolutionDto
-    {
-        public string ResolutionComments { get; set; }
-        public DateTime ResolutionDate { get; set; }
-    }
+namespace SensorApp.Shared.Dtos.Incident;
 
+/// <summary>
+/// Data Transfer Object (DTO) used for providing the resolution details of an incident.
+/// This DTO contains the necessary information to mark an incident as resolved, including comments and resolution date.
+/// </summary>
+public class IncidentResolutionDto
+{
+    public required string ResolutionComments { get; set; }
+    public required DateTime ResolutionDate { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Incident/IncidentResolutionDto.cs
@@ -13,5 +13,5 @@ namespace SensorApp.Shared.Dtos.Incident;
 public class IncidentResolutionDto
 {
     public required string ResolutionComments { get; set; }
-    public required DateTime ResolutionDate { get; set; }
+    public DateTime ResolutionDate { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Enums/IncidentPriority.cs
+++ b/SensorApp/SensorApp.Shared/Enums/IncidentPriority.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SensorApp.Shared.Enums;
+
+public enum IncidentPriority
+{
+    [Display(Name = "High")]
+    High,
+    [Display(Name = "Medium")]
+    Medium,
+    [Display(Name = "Low")]
+    Low
+}

--- a/SensorApp/SensorApp.Shared/Enums/IncidentStatus.cs
+++ b/SensorApp/SensorApp.Shared/Enums/IncidentStatus.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace SensorApp.Shared.Enums;
+
+public enum IncidentStatus
+{
+    [Display(Name = "Open")]
+    Open,
+    [Display(Name = "Resolved")]
+    Resolved
+}

--- a/SensorApp/SensorApp.Shared/Enums/IncidentType.cs
+++ b/SensorApp/SensorApp.Shared/Enums/IncidentType.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SensorApp.Shared.Enums;
+
+public enum IncidentType
+{
+    [Display(Name = "Max threshold breached")]
+    MaxThresholdBreached,
+    [Display(Name = "Min threshold breached")]
+    MinThresholdBreached,
+    [Display(Name = "Sensor unresponsive")]
+    SensorUnresponsive
+}

--- a/SensorApp/SensorApp.Shared/Factories/AdminMenuFactory.cs
+++ b/SensorApp/SensorApp.Shared/Factories/AdminMenuFactory.cs
@@ -35,6 +35,11 @@ public class AdminMenuFactory : IMenuFactory
             {
                 Title = "Historical Data",        
                 Route = "HistoricalDataPage" 
+            },
+            new AppMenuItem
+            {
+                Title = "Incident List",
+                Route = "IncidentList"
             }
         ];
     }

--- a/SensorApp/SensorApp.Shared/Factories/OperationsMenuFactory.cs
+++ b/SensorApp/SensorApp.Shared/Factories/OperationsMenuFactory.cs
@@ -17,6 +17,11 @@ public class OperationsMenuFactory : IMenuFactory
             {
                 Title = "Sensor Map",
                 Route = "SensorMapPage"
+            },
+            new AppMenuItem
+            {
+                Title = "Incident List",
+                Route = "IncidentList"
             }
         ];
     }

--- a/SensorApp/SensorApp.Shared/Helpers/HttpRequestHelper.cs
+++ b/SensorApp/SensorApp.Shared/Helpers/HttpRequestHelper.cs
@@ -28,6 +28,8 @@ public static class HttpRequestHelper
         var request = new HttpRequestMessage(method, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
+        Console.WriteLine("Built request: " + request?.RequestUri);
+
         if (content is not null)
         {
             var json = JsonSerializer.Serialize(content, _jsonOptions);

--- a/SensorApp/SensorApp.Shared/Helpers/HttpRequestHelper.cs
+++ b/SensorApp/SensorApp.Shared/Helpers/HttpRequestHelper.cs
@@ -28,8 +28,6 @@ public static class HttpRequestHelper
         var request = new HttpRequestMessage(method, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        Console.WriteLine("Built request: " + request?.RequestUri);
-
         if (content is not null)
         {
             var json = JsonSerializer.Serialize(content, _jsonOptions);

--- a/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
@@ -5,4 +5,5 @@ namespace SensorApp.Shared.Interfaces;
 public interface IIncidentApiService
 {
     Task<List<IncidentDto>> GetAllIncidentsAsync(string token);
+    Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
@@ -6,4 +6,5 @@ public interface IIncidentApiService
 {
     Task<List<IncidentDto>> GetAllIncidentsAsync(string token);
     Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident);
+    Task<bool> ResolveIncidentAsync(string token, int incidentId, IncidentResolutionDto dto);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
@@ -2,10 +2,38 @@
 
 namespace SensorApp.Shared.Interfaces;
 
+/// <summary>
+/// Interface for incident-related API service.
+/// Defines methods for interacting with the incident API, such as retrieving, adding, resolving, and deleting incidents.
+/// </summary>
 public interface IIncidentApiService
 {
+    /// <summary>
+    /// Asynchronously retrieves all incidents from the API.
+    /// </summary>
+    /// <param name="token">The authorization token required to make the request.</param>
+    /// <returns>A list of <see cref="IncidentDto"/> representing the incidents.</returns>
     Task<List<IncidentDto>> GetAllIncidentsAsync(string token);
+    /// <summary>
+    /// Asynchronously adds a new incident via the API.
+    /// </summary>
+    /// <param name="token">The authorization token required to make the request.</param>
+    /// <param name="newIncident">The incident data to be created.</param>
+    /// <returns>True if the incident was successfully added; otherwise, false.</returns>
     Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident);
+    /// <summary>
+    /// Asynchronously resolves an incident via the API.
+    /// </summary>
+    /// <param name="token">The authorization token required to make the request.</param>
+    /// <param name="incidentId">The unique identifier of the incident to resolve.</param>
+    /// <param name="dto">The resolution details for the incident.</param>
+    /// <returns>True if the incident was successfully resolved; otherwise, false.</returns>
     Task<bool> ResolveIncidentAsync(string token, int incidentId, IncidentResolutionDto dto);
+    /// <summary>
+    /// Asynchronously deletes an incident via the API.
+    /// </summary>
+    /// <param name="token">The authorization token required to make the request.</param>
+    /// <param name="incidentId">The unique identifier of the incident to delete.</param>
+    /// <returns>True if the incident was successfully deleted; otherwise, false.</returns>
     Task<bool> DeleteIncidentAsync(string token, int incidentId);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
@@ -7,4 +7,5 @@ public interface IIncidentApiService
     Task<List<IncidentDto>> GetAllIncidentsAsync(string token);
     Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident);
     Task<bool> ResolveIncidentAsync(string token, int incidentId, IncidentResolutionDto dto);
+    Task<bool> DeleteIncidentAsync(string token, int incidentId);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IIncidentApiService.cs
@@ -1,0 +1,8 @@
+﻿using SensorApp.Shared.Dtos.Incident;
+
+namespace SensorApp.Shared.Interfaces;
+
+public interface IIncidentApiService
+{
+    Task<List<IncidentDto>> GetAllIncidentsAsync(string token);
+}

--- a/SensorApp/SensorApp.Shared/Interfaces/ISensorApiService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/ISensorApiService.cs
@@ -1,0 +1,19 @@
+﻿using SensorApp.Shared.Models;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SensorApp.Shared.Interfaces
+{
+    /// <summary>
+    /// Interface for interacting with the sensor API.
+    /// </summary>
+    public interface ISensorApiService
+    {
+        /// <summary>
+        /// Fetches a list of sensors from the API using the provided authentication token.
+        /// </summary>
+        /// <param name="token">The authentication token used for authorization in the request.</param>
+        /// <returns>A list of <see cref="SensorModel"/> representing the sensors, or an empty list if an error occurs.</returns>
+        Task<List<SensorModel>> GetSensorsAsync(string token);
+    }
+}

--- a/SensorApp/SensorApp.Shared/Models/Incident.cs
+++ b/SensorApp/SensorApp.Shared/Models/Incident.cs
@@ -1,0 +1,15 @@
+﻿namespace SensorApp.Shared.Models;
+using SensorApp.Shared.Dtos.Admin;
+public class Incident : BaseEntity
+{
+    public string Type { get; set; }
+    public string Status { get; set; }
+    public SensorModel Sensor { get; set; }
+    public int Sensor_id { get; set; }
+    public DateTime Creation_date { get; set; }
+    public string Priority { get; set; }
+    public DateTime? Resolution_date { get; set; }
+    public string Responder_id { get; set; }
+    public UserWithRoleDto Responder { get; set; }
+    public string? Comments { get; set; }
+}

--- a/SensorApp/SensorApp.Shared/Models/Incident.cs
+++ b/SensorApp/SensorApp.Shared/Models/Incident.cs
@@ -1,15 +1,21 @@
 ﻿namespace SensorApp.Shared.Models;
 using SensorApp.Shared.Dtos.Admin;
+
+/// <summary>
+/// Represents an incident in the system.
+/// This model contains all the details related to a specific incident, including the type, status, sensor, priority, and resolution details.
+/// It inherits from <see cref="BaseEntity"/> which includes the common property Id.
+/// </summary>
 public class Incident : BaseEntity
 {
-    public string Type { get; set; }
-    public string Status { get; set; }
-    public SensorModel Sensor { get; set; }
-    public int Sensor_id { get; set; }
-    public DateTime Creation_date { get; set; }
-    public string Priority { get; set; }
+    public required string Type { get; set; }
+    public required string Status { get; set; }
+    public required SensorModel Sensor { get; set; }
+    public required int Sensor_id { get; set; }
+    public required DateTime Creation_date { get; set; }
+    public required string Priority { get; set; }
     public DateTime? Resolution_date { get; set; }
-    public string Responder_id { get; set; }
-    public UserWithRoleDto Responder { get; set; }
+    public required string Responder_id { get; set; }
+    public required UserWithRoleDto Responder { get; set; }
     public string? Comments { get; set; }
 }

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -41,4 +41,10 @@ public class IncidentApiService : IIncidentApiService
         var request = HttpRequestHelper.Create(HttpMethod.Post, "/incident/create", token, newIncident);
         return await HttpRequestHelper.SendAsync(_httpClient, request);
     }
+
+    public async Task<bool> ResolveIncidentAsync(string token, int incidentId, IncidentResolutionDto dto)
+    {
+        var request = HttpRequestHelper.Create(HttpMethod.Put, $"/incident/resolve/{incidentId}", token, dto);
+        return await HttpRequestHelper.SendAsync(_httpClient, request);
+    }
 }

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -1,0 +1,37 @@
+﻿using System.Net.Http.Headers;
+using System.Text.Json;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Helpers;
+using SensorApp.Shared.Interfaces;
+using SensorApp.Shared.Models;
+
+namespace SensorApp.Shared.Services;
+public class IncidentApiService : IIncidentApiService
+{
+    private readonly HttpClient _httpClient;
+
+    public IncidentApiService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+
+    }
+
+    public async Task<List<IncidentDto>> GetAllIncidentsAsync(string token)
+    {
+        try
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var response = await _httpClient.GetAsync("/incidents");
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+
+            return JsonSerializer.Deserialize<List<IncidentDto>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error fetching incidents: {ex.Message}");
+            return new List<IncidentDto>();
+        }
+    }
+}

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -29,7 +29,7 @@ public class IncidentApiService : IIncidentApiService
         {
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            var response = await _httpClient.GetAsync("/incidents");
+            var response = await _httpClient.GetAsync("/incident");
             response.EnsureSuccessStatusCode();
             var json = await response.Content.ReadAsStringAsync();
 

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -47,4 +47,10 @@ public class IncidentApiService : IIncidentApiService
         var request = HttpRequestHelper.Create(HttpMethod.Put, $"/incident/resolve/{incidentId}", token, dto);
         return await HttpRequestHelper.SendAsync(_httpClient, request);
     }
+
+    public async Task<bool> DeleteIncidentAsync(string token, int incidentId)
+    {
+        var request = HttpRequestHelper.Create(HttpMethod.Delete, $"/incident/delete/{incidentId}", token);
+        return await HttpRequestHelper.SendAsync(_httpClient, request);
+    }
 }

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using System.Text.Json;
+using SensorApp.Shared.Dtos.Admin;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Helpers;
 using SensorApp.Shared.Interfaces;
@@ -33,5 +34,11 @@ public class IncidentApiService : IIncidentApiService
             Console.WriteLine($"Error fetching incidents: {ex.Message}");
             return new List<IncidentDto>();
         }
+    }
+
+    public async Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident)
+    {
+        var request = HttpRequestHelper.Create(HttpMethod.Post, "/incident/create", token, newIncident);
+        return await HttpRequestHelper.SendAsync(_httpClient, request);
     }
 }

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -25,21 +25,9 @@ public class IncidentApiService : IIncidentApiService
 
     public async Task<List<IncidentDto>> GetAllIncidentsAsync(string token)
     {
-        try
-        {
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            var response = await _httpClient.GetAsync("/incident");
-            response.EnsureSuccessStatusCode();
-            var json = await response.Content.ReadAsStringAsync();
-
-            return JsonSerializer.Deserialize<List<IncidentDto>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error fetching incidents: {ex.Message}");
-            return new List<IncidentDto>();
-        }
+        var request = HttpRequestHelper.Create(HttpMethod.Get, "/incident", token);
+        var incidents = await HttpRequestHelper.SendAsync<List<IncidentDto>>(_httpClient, request);
+        return incidents ?? new List<IncidentDto>();
     }
 
     public async Task<bool> AddIncidentAsync(string token, CreateIncidentDto newIncident)

--- a/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/IncidentApiService.cs
@@ -7,6 +7,12 @@ using SensorApp.Shared.Interfaces;
 using SensorApp.Shared.Models;
 
 namespace SensorApp.Shared.Services;
+
+/// <summary>
+/// Service class for interacting with the Incident API.
+/// This class provides methods to perform CRUD operations related to incidents, 
+/// such as fetching, creating, resolving, and deleting incidents.
+/// </summary>
 public class IncidentApiService : IIncidentApiService
 {
     private readonly HttpClient _httpClient;

--- a/SensorApp/SensorApp.Shared/Services/SensorApiService.cs
+++ b/SensorApp/SensorApp.Shared/Services/SensorApiService.cs
@@ -1,4 +1,5 @@
-﻿using SensorApp.Shared.Models;
+﻿using SensorApp.Shared.Interfaces;
+using SensorApp.Shared.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -8,7 +9,7 @@ namespace SensorApp.Shared.Services;
 /// <summary>
 /// Provides services for interacting with the API to retrieve sensor data.
 /// </summary>
-public class SensorApiService
+public class SensorApiService : ISensorApiService
 {
     private readonly HttpClient _httpClient;
 

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
@@ -24,7 +24,7 @@ namespace SensorApp.Tests.IntegrationTests
         {
             //Arrange
             var token = await _tokenProvider.GetOpsTokenAsync();
-            var request = TestHelpers.CreateAuthorizedRequest("/incidents", token);
+            var request = TestHelpers.CreateAuthorizedRequest("/incident", token);
 
             // Act
             var response = await _client.SendAsync(request);
@@ -40,7 +40,7 @@ namespace SensorApp.Tests.IntegrationTests
         public async Task GetIncidents_ReturnsUnauthorized_WhenNotAuthenticated()
         {
             // Arrange
-            var request = TestHelpers.CreateAuthorizedRequest("/incidents", "");
+            var request = TestHelpers.CreateAuthorizedRequest("/incident", "");
 
             // Act
             var response = await _client.SendAsync(request);

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
@@ -1,0 +1,219 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using SensorApp.Shared.Dtos.Admin;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Tests.IntegrationTests.ApiEndpoints.Helpers;
+
+
+namespace SensorApp.Tests.IntegrationTests
+{
+    public class IncidentEndpointsTests : IClassFixture<WebApplicationFactoryForTests>
+    {
+        private readonly HttpClient _client;
+        private readonly TokenProvider _tokenProvider;
+
+        public IncidentEndpointsTests(WebApplicationFactoryForTests factory)
+        {
+            _client = factory.CreateClient();
+            _tokenProvider = new TokenProvider(_client);
+        }
+
+        [Fact]
+        public async Task GetIncidents_ReturnsOkResponse_WithIncidents()
+        {
+            //Arrange
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incidents", token);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var incidents = await response.Content.ReadFromJsonAsync<List<IncidentDto>>();
+            Assert.NotNull(incidents);
+        }
+
+        [Fact]
+        public async Task GetIncidents_ReturnsUnauthorized_WhenNotAuthenticated()
+        {
+            // Arrange
+            var request = TestHelpers.CreateAuthorizedRequest("/incidents", "");
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateIncident_ReturnsOkResponse_WithValidData()
+        {
+            // Arrange
+            var newIncident = new CreateIncidentDto
+            {
+                Type = "Max threshold breach",
+                Status = "Open",
+                SensorId = 1,
+                Priority = "High",
+                Comments = "High concentration"
+            };
+
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/create", token, HttpMethod.Post, newIncident);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateIncident_ReturnsBadRequest_WhenInvalidData()
+        {
+            // Arrange
+            var invalidIncident = new CreateIncidentDto
+            {
+                Type = "Max threshold breach",
+                Status = "Open",
+                Priority = "High",
+                Comments = "High concentration"
+            };
+
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/create", token, HttpMethod.Post, invalidIncident);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateIncident_ReturnsUnauthorized_WhenNotAuthenticated()
+        {
+            // Arrange
+            var newIncident = new CreateIncidentDto
+            {
+                Type = "Max threshold breach",
+                Status = "Open",
+                SensorId = 1,
+                Priority = "High",
+                Comments = "High concentration"
+            };
+
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/create", "", HttpMethod.Post, newIncident);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResolveIncident_ReturnsOkResponse_WhenResolvedSuccessfully()
+        {
+            // Arrange
+            var incidentResolutionDto = new IncidentResolutionDto
+            {
+                ResolutionComments = "Resolved after verification"
+            };
+
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/resolve/1", token, HttpMethod.Put, incidentResolutionDto);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            response.EnsureSuccessStatusCode(); 
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResolveIncident_ReturnsUnauthorized_WhenNotAuthenticated()
+        {
+            // Arrange
+            var incidentResolutionDto = new IncidentResolutionDto
+            {
+                ResolutionComments = "Resolved after verification"
+            };
+
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/resolve/1", "", HttpMethod.Put, incidentResolutionDto);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ResolveIncident_ReturnsNotFound_WhenIncidentDoesNotExist()
+        {
+            // Arrange
+            var incidentResolutionDto = new IncidentResolutionDto
+            {
+                ResolutionComments = "Resolved after verification"
+            };
+
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/resolve/999", token, HttpMethod.Put, incidentResolutionDto);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteIncident_ReturnsOkResponse_WhenDeletedSuccessfully()
+        {
+            //Arrange
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/delete/1", token, HttpMethod.Delete);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteIncident_ReturnsNotFound_WhenIncidentDoesNotExist()
+        {
+            //Arrange
+            var token = await _tokenProvider.GetOpsTokenAsync();
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/delete/999", token, HttpMethod.Delete);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteIncident_ReturnsUnauthorized_WhenNotAuthenticated()
+        {
+            //Arrange
+            var request = TestHelpers.CreateAuthorizedRequest("/incident/delete/1", "", HttpMethod.Delete);
+
+            // Act
+            var response = await _client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+}

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/IncidentEndpoints/IncidentEndpointTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using SensorApp.Shared.Dtos.Admin;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Tests.IntegrationTests.ApiEndpoints.Helpers;
+using SensorApp.Shared.Enums;
 
 
 namespace SensorApp.Tests.IntegrationTests
@@ -55,10 +56,10 @@ namespace SensorApp.Tests.IntegrationTests
             // Arrange
             var newIncident = new CreateIncidentDto
             {
-                Type = "Max threshold breach",
-                Status = "Open",
+                Type = IncidentType.MaxThresholdBreached,
+                Status = IncidentStatus.Open,
                 SensorId = 1,
-                Priority = "High",
+                Priority = IncidentPriority.High,
                 Comments = "High concentration"
             };
 
@@ -70,7 +71,11 @@ namespace SensorApp.Tests.IntegrationTests
 
             // Assert
             response.EnsureSuccessStatusCode();
+            var created = await response.Content.ReadFromJsonAsync<IncidentDto>();
+
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(newIncident.Type, created.Type);
+            Assert.Equal(newIncident.Comments, created.Comments);
         }
 
         [Fact]
@@ -79,9 +84,9 @@ namespace SensorApp.Tests.IntegrationTests
             // Arrange
             var invalidIncident = new CreateIncidentDto
             {
-                Type = "Max threshold breach",
-                Status = "Open",
-                Priority = "High",
+                Type = IncidentType.MaxThresholdBreached,
+                Status = IncidentStatus.Open,
+                Priority = IncidentPriority.High,
                 Comments = "High concentration"
             };
 
@@ -101,10 +106,10 @@ namespace SensorApp.Tests.IntegrationTests
             // Arrange
             var newIncident = new CreateIncidentDto
             {
-                Type = "Max threshold breach",
-                Status = "Open",
+                Type = IncidentType.MaxThresholdBreached,
+                Status = IncidentStatus.Open,
                 SensorId = 1,
-                Priority = "High",
+                Priority = IncidentPriority.High,
                 Comments = "High concentration"
             };
 

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
@@ -1,0 +1,157 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SensorApp.Api.Services;
+using SensorApp.Database.Data;
+using SensorApp.Database.Models;
+using SensorApp.Shared.Dtos.Incident;
+using Microsoft.AspNetCore.Identity;
+
+public class IncidentServiceTests
+{
+    private SensorDbContext GetDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<SensorDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+
+        return new SensorDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetAllIncidentsAsync_ReturnsList()
+    {
+        // Arrange
+        var context = GetDbContext("GetAllIncidentsDb");
+        var incident = new Incident
+        {
+            Id = 1,
+            Type = "Max threshold breach",
+            Status = "Open",
+            Sensor_id = 1,
+            Priority = "High",
+            Creation_date = DateTime.UtcNow,
+            Comments = "High concentrations of Nitrogen Dioxide",
+            Responder_id = "responder",
+            Sensor = new Sensor
+            {
+                Id = 1,
+                Type = "Air quality",
+                Latitude = 52f,
+                Longitude = 10f,
+                Site_zone = "Zone ",
+                Status = "Active"
+            },
+            Responder = new IdentityUser
+            {
+                Id = "responder",
+                UserName = "ResponderUser"
+            }
+        };
+        context.Incidents.Add(incident);
+        await context.SaveChangesAsync();
+
+        var service = new IncidentService(context);
+
+        // Act
+        var result = await service.GetAllIncidentsAsync();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Max threshold breach", result[0].Type);
+        Assert.Equal("ResponderUser", result[0].Responder.Username);
+        Assert.Equal("Air quality", result[0].Sensor.Type);
+    }
+
+    [Fact]
+    public async Task CreateIncidentAsync_AddsIncident()
+    {
+        var context = GetDbContext("CreateIncidentDb");
+        var service = new IncidentService(context);
+
+        var dto = new CreateIncidentDto
+        {
+            Type = "Sensor unresponsive",
+            Status = "Open",
+            SensorId = 2,
+            Priority = "High",
+            Comments = "No measurements in 24h"
+        };
+
+        // Act
+        await service.CreateIncidentAsync(dto, "responder2");
+
+        // Assert
+        var incident = await context.Incidents.FirstOrDefaultAsync();
+        Assert.NotNull(incident);
+        Assert.Equal("Sensor unresponsive", incident.Type);
+        Assert.Equal("responder2", incident.Responder_id);
+    }
+
+    [Fact]
+    public async Task ResolveIncidentAsync_UpdatesIncident()
+    {
+        var context = GetDbContext("ResolveIncidentDb");
+        var incident = new Incident
+        {
+            Id = 1,
+            Type = "Min threshold breach",
+            Status = "Open",
+            Comments = "Low quantities of nitrogen dioxide",
+            Creation_date = DateTime.UtcNow,
+            Priority = "High", 
+            Responder_id = "responderID"
+        };
+        context.Incidents.Add(incident);
+        await context.SaveChangesAsync();
+
+        var service = new IncidentService(context);
+
+        var dto = new IncidentResolutionDto { ResolutionComments = "Incident resolved" };
+
+        // Act
+        var result = await service.ResolveIncidentAsync(1, dto);
+
+        // Assert
+        Assert.True(result);
+        var updated = await context.Incidents.FindAsync(1);
+        Assert.Equal("Resolved", updated.Status);
+        Assert.Equal("Incident resolved", updated.Comments);
+        Assert.NotNull(updated.Resolution_date);
+    }
+
+    [Fact]
+    public async Task ResolveIncidentAsync_ReturnsFalse_IfNotFound()
+    {
+        var context = GetDbContext("ResolveNotFoundDb");
+        var service = new IncidentService(context);
+
+        var result = await service.ResolveIncidentAsync(404, new IncidentResolutionDto());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DeleteIncidentAsync_RemovesIncident()
+    {
+        var context = GetDbContext("DeleteIncidentDb");
+        context.Incidents.Add(new Incident { Id = 1, Type = "Max threshold breach", Priority = "Medium", Responder_id = "responderID", Status = "Open" });
+        await context.SaveChangesAsync();
+
+        var service = new IncidentService(context);
+
+        var result = await service.DeleteIncidentAsync(1);
+
+        Assert.True(result);
+        Assert.Empty(await context.Incidents.ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeleteIncidentAsync_ReturnsFalse_IfNotFound()
+    {
+        var context = GetDbContext("DeleteNotFoundDb");
+        var service = new IncidentService(context);
+
+        var result = await service.DeleteIncidentAsync(404);
+
+        Assert.False(result);
+    }
+}

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
@@ -128,7 +128,7 @@ public class IncidentServiceTests
         var service = new IncidentService(context);
 
         //Act
-        var result = await service.ResolveIncidentAsync(404, new IncidentResolutionDto());
+        var result = await service.ResolveIncidentAsync(404, new IncidentResolutionDto { ResolutionComments = "Incident resolved" });
 
         //Assert
         Assert.False(result);

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
@@ -64,6 +64,7 @@ public class IncidentServiceTests
     [Fact]
     public async Task CreateIncidentAsync_AddsIncident()
     {
+        //Arrange
         var context = GetDbContext("CreateIncidentDb");
         var service = new IncidentService(context);
 
@@ -89,6 +90,7 @@ public class IncidentServiceTests
     [Fact]
     public async Task ResolveIncidentAsync_UpdatesIncident()
     {
+        //Arrange
         var context = GetDbContext("ResolveIncidentDb");
         var incident = new Incident
         {
@@ -121,25 +123,31 @@ public class IncidentServiceTests
     [Fact]
     public async Task ResolveIncidentAsync_ReturnsFalse_IfNotFound()
     {
+        //Arrange
         var context = GetDbContext("ResolveNotFoundDb");
         var service = new IncidentService(context);
 
+        //Act
         var result = await service.ResolveIncidentAsync(404, new IncidentResolutionDto());
 
+        //Assert
         Assert.False(result);
     }
 
     [Fact]
     public async Task DeleteIncidentAsync_RemovesIncident()
     {
+        //Arrange
         var context = GetDbContext("DeleteIncidentDb");
         context.Incidents.Add(new Incident { Id = 1, Type = "Max threshold breach", Priority = "Medium", Responder_id = "responderID", Status = "Open" });
         await context.SaveChangesAsync();
 
         var service = new IncidentService(context);
 
+        //Act
         var result = await service.DeleteIncidentAsync(1);
 
+        //Assert
         Assert.True(result);
         Assert.Empty(await context.Incidents.ToListAsync());
     }
@@ -147,11 +155,14 @@ public class IncidentServiceTests
     [Fact]
     public async Task DeleteIncidentAsync_ReturnsFalse_IfNotFound()
     {
+        //Arrange
         var context = GetDbContext("DeleteNotFoundDb");
         var service = new IncidentService(context);
 
+        //Act
         var result = await service.DeleteIncidentAsync(404);
 
+        //Assert
         Assert.False(result);
     }
 }

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Services/IncidentServiceTests.cs
@@ -4,6 +4,7 @@ using SensorApp.Database.Data;
 using SensorApp.Database.Models;
 using SensorApp.Shared.Dtos.Incident;
 using Microsoft.AspNetCore.Identity;
+using SensorApp.Shared.Enums;
 
 public class IncidentServiceTests
 {
@@ -24,10 +25,10 @@ public class IncidentServiceTests
         var incident = new Incident
         {
             Id = 1,
-            Type = "Max threshold breach",
-            Status = "Open",
+            Type = IncidentType.MaxThresholdBreached,
+            Status = IncidentStatus.Open,
             Sensor_id = 1,
-            Priority = "High",
+            Priority = IncidentPriority.High,
             Creation_date = DateTime.UtcNow,
             Comments = "High concentrations of Nitrogen Dioxide",
             Responder_id = "responder",
@@ -56,7 +57,7 @@ public class IncidentServiceTests
 
         // Assert
         Assert.Single(result);
-        Assert.Equal("Max threshold breach", result[0].Type);
+        Assert.Equal(IncidentType.MaxThresholdBreached, result[0].Type);
         Assert.Equal("ResponderUser", result[0].Responder.Username);
         Assert.Equal("Air quality", result[0].Sensor.Type);
     }
@@ -70,10 +71,10 @@ public class IncidentServiceTests
 
         var dto = new CreateIncidentDto
         {
-            Type = "Sensor unresponsive",
-            Status = "Open",
+            Type = IncidentType.SensorUnresponsive,
+            Status = IncidentStatus.Open,
             SensorId = 2,
-            Priority = "High",
+            Priority = IncidentPriority.High,
             Comments = "No measurements in 24h"
         };
 
@@ -83,7 +84,7 @@ public class IncidentServiceTests
         // Assert
         var incident = await context.Incidents.FirstOrDefaultAsync();
         Assert.NotNull(incident);
-        Assert.Equal("Sensor unresponsive", incident.Type);
+        Assert.Equal(IncidentType.SensorUnresponsive, incident.Type);
         Assert.Equal("responder2", incident.Responder_id);
     }
 
@@ -95,11 +96,11 @@ public class IncidentServiceTests
         var incident = new Incident
         {
             Id = 1,
-            Type = "Min threshold breach",
-            Status = "Open",
+            Type = IncidentType.MinThresholdBreached,
+            Status = IncidentStatus.Open,
             Comments = "Low quantities of nitrogen dioxide",
             Creation_date = DateTime.UtcNow,
-            Priority = "High", 
+            Priority = IncidentPriority.Medium, 
             Responder_id = "responderID"
         };
         context.Incidents.Add(incident);
@@ -115,7 +116,7 @@ public class IncidentServiceTests
         // Assert
         Assert.True(result);
         var updated = await context.Incidents.FindAsync(1);
-        Assert.Equal("Resolved", updated.Status);
+        Assert.Equal(IncidentStatus.Resolved, updated.Status);
         Assert.Equal("Incident resolved", updated.Comments);
         Assert.NotNull(updated.Resolution_date);
     }
@@ -139,7 +140,7 @@ public class IncidentServiceTests
     {
         //Arrange
         var context = GetDbContext("DeleteIncidentDb");
-        context.Incidents.Add(new Incident { Id = 1, Type = "Max threshold breach", Priority = "Medium", Responder_id = "responderID", Status = "Open" });
+        context.Incidents.Add(new Incident { Id = 1, Type = IncidentType.MinThresholdBreached, Priority = IncidentPriority.Medium, Responder_id = "responderID", Status = IncidentStatus.Open });
         await context.SaveChangesAsync();
 
         var service = new IncidentService(context);

--- a/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
@@ -17,5 +17,6 @@ public class OperationsMenuFactoryTests
         menu.Should().NotBeNullOrEmpty("Operations manager menu should have at least one item");
 
         menu.Should().Contain(item => item.Route == "SensorMapPage");
+        menu.Should().Contain(item => item.Route == "IncidentList");
     }
 }

--- a/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
@@ -8,7 +8,7 @@ public class OperationsMenuFactoryTests
     public void Operations_CreateMenu_ShouldReturnExpectedMenuItems()
     {
         // Arrange
-        AdminMenuFactory factory = new();
+        OperationsMenuFactory factory = new();
 
         // Act
         var menu = factory.CreateMenu().ToList();

--- a/SensorApp/SensorApp.Tests/UnitTests/Services/IncidentApiServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Services/IncidentApiServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using SensorApp.Shared.Dtos.Incident;
 using SensorApp.Shared.Services;
+using SensorApp.Shared.Enums;
 
 namespace SensorApp.Tests.UnitTests.Services;
 
@@ -17,11 +18,11 @@ public class IncidentApiServiceTests
             new IncidentDto
             {
                 Id = 1,
-                Type = "Max threshold breach",
-                Status = "Open",
+                Type = IncidentType.MaxThresholdBreached,
+                Status = IncidentStatus.Open,
                 Sensor_id = 1,
                 Creation_date = DateTime.UtcNow,
-                Priority = "High",
+                Priority = IncidentPriority.High,
                 Comments = "Test incident"
             }
         };
@@ -46,7 +47,7 @@ public class IncidentApiServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.Single(result);
-        Assert.Equal("Max threshold breach", result[0].Type);
+        Assert.Equal(IncidentType.MaxThresholdBreached, result[0].Type);
     }
 
     [Fact]
@@ -87,10 +88,10 @@ public class IncidentApiServiceTests
         // Arrange
         var newIncident = new CreateIncidentDto
         {
-            Type = "Max threshold breach",
-            Status = "Open",
+            Type = IncidentType.MaxThresholdBreached,
+            Status = IncidentStatus.Open,
             SensorId = 1,
-            Priority = "High",
+            Priority = IncidentPriority.High,
             Comments = "New test incident"
         };
 
@@ -112,10 +113,10 @@ public class IncidentApiServiceTests
         // Arrange
         var newIncident = new CreateIncidentDto
         {
-            Type = "Max threshold breach",
-            Status = "Open",
+            Type = IncidentType.MaxThresholdBreached,
+            Status = IncidentStatus.Open,
             SensorId = 1,
-            Priority = "High",
+            Priority = IncidentPriority.Low,
             Comments = "New test incident"
         };
 

--- a/SensorApp/SensorApp.Tests/UnitTests/Services/IncidentApiServiceTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Services/IncidentApiServiceTests.cs
@@ -1,0 +1,207 @@
+﻿using System.Net;
+using System.Text;
+using System.Text.Json;
+using SensorApp.Shared.Dtos.Incident;
+using SensorApp.Shared.Services;
+
+namespace SensorApp.Tests.UnitTests.Services;
+
+public class IncidentApiServiceTests
+{
+    [Fact]
+    public async Task GetAllIncidentsAsync_ReturnsListOfIncidents_WhenSuccessful()
+    {
+        // Arrange
+        var mockIncidents = new List<IncidentDto>
+        {
+            new IncidentDto
+            {
+                Id = 1,
+                Type = "Max threshold breach",
+                Status = "Open",
+                Sensor_id = 1,
+                Creation_date = DateTime.UtcNow,
+                Priority = "High",
+                Comments = "Test incident"
+            }
+        };
+
+        var responseContent = new StringContent(
+            JsonSerializer.Serialize(mockIncidents),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = responseContent
+        };
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.GetAllIncidentsAsync("validToken");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("Max threshold breach", result[0].Type);
+    }
+
+    [Fact]
+    public async Task GetAllIncidentsAsync_ReturnsEmptyList_WhenUnauthorized_Following401Response()
+    {
+        // Arrange
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.GetAllIncidentsAsync("unauthorizedToken");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllIncidentsAsync_ReturnsEmptyList_OnError()
+    {
+        // Arrange
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.GetAllIncidentsAsync("badToken");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddIncidentAsync_ReturnsTrue_WhenIncidentAddedSuccessfully()
+    {
+        // Arrange
+        var newIncident = new CreateIncidentDto
+        {
+            Type = "Max threshold breach",
+            Status = "Open",
+            SensorId = 1,
+            Priority = "High",
+            Comments = "New test incident"
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.AddIncidentAsync("validToken", newIncident);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AddIncidentAsync_ReturnsFalse_WhenFailedToAddIncident()
+    {
+        // Arrange
+        var newIncident = new CreateIncidentDto
+        {
+            Type = "Max threshold breach",
+            Status = "Open",
+            SensorId = 1,
+            Priority = "High",
+            Comments = "New test incident"
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.AddIncidentAsync("badToken", newIncident);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ResolveIncidentAsync_ReturnsTrue_WhenIncidentResolvedSuccessfully()
+    {
+        // Arrange
+        var resolutionDto = new IncidentResolutionDto
+        {
+            ResolutionComments = "Incident resolved successfully."
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.ResolveIncidentAsync("validToken", 1, resolutionDto);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ResolveIncidentAsync_ReturnsFalse_WhenFailedToResolveIncident()
+    {
+        // Arrange
+        var resolutionDto = new IncidentResolutionDto
+        {
+            ResolutionComments = "Incident resolution failed."
+        };
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.ResolveIncidentAsync("badToken", 1, resolutionDto);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DeleteIncidentAsync_ReturnsTrue_WhenIncidentDeletedSuccessfully()
+    {
+        // Arrange
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.DeleteIncidentAsync("validToken", 1);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task DeleteIncidentAsync_ReturnsFalse_WhenFailedToDeleteIncident()
+    {
+        // Arrange
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var httpClient = HttpClientTestFactory.Create(response);
+        var apiService = new IncidentApiService(httpClient);
+
+        // Act
+        var result = await apiService.DeleteIncidentAsync("badToken", 1);
+
+        // Assert
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
This PR centres on the addition of Incidents to the application, including a new `Incident` table in the db, APIs to carry out CRUD operations on the `Incident`s and new pages to view incidents, create new incidents and view details of specific incidents.

New API endpoints are added to retrieve all incident data, specific incident data by Id, delete incidents or resolve incidents. These endpoints are called from a new IncidentApiService, which is utilized in the ViewModel for the IncidentList view page. 

Appropriate DTOs and models are also added for Incident, CreateIncident and ResolveIncident objects.

The previously implemented SensorApiService has now been abstracted into an interface, and where it was directly implemented before, it has been replaced with the interface implementation. This aims to fix a violation of Dependency Inversion which was present in both the SensorMapPage, and in the CreateIncident page from this PR.

Unit tests are added for the new IncidentApiService, as well as integration tests for the IncidentService handling the API endpoints.