### PR TITLE
Add Doxygen friendly comments and small change to pipeline

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,6 +39,8 @@ jobs:
           sed -i 's|^# OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
           sed -i 's|^# FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
           sed -i 's|^# EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile
+          sed -i 's|^SOURCE_BROWSER .*|SOURCE_BROWSER = YES|' Doxygen Doxyfile
+          sed -i 's|^INLINE_SOURCES .*|INLINE_SOURCES = YES|' Doxyfile
 
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,9 @@ jobs:
           sed -i 's|^# EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
           sed -i 's|^# EXTRACT_PRIVATE .*|EXTRACT_PRIVATE = YES|' Doxyfile
           sed -i 's|^# EXTRACT_STATIC .*|EXTRACT_STATIC = YES|' Doxyfile
+          sed -i 's|^# OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
+          sed -i 's|^# FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
+          sed -i 's|^# EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile
 
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,6 +30,8 @@ jobs:
           sed -i 's|^# INPUT .*|INPUT = ./|' Doxyfile
           sed -i 's|^RECURSIVE .*|RECURSIVE = YES|' Doxyfile
           sed -i 's|^# EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
+          sed -i 's|^# EXTRACT_PRIVATE .*|EXTRACT_PRIVATE = YES|' Doxyfile
+          sed -i 's|^# EXTRACT_STATIC .*|EXTRACT_STATIC = YES|' Doxyfile
 
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install Doxygen
         run: sudo apt-get install doxygen -y
 
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz -y
+
       - name: Generate default Doxyfile
         run: doxygen -g
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
           sed -i 's|^# OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
           sed -i 's|^# FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
           sed -i 's|^# EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile
-          sed -i 's|^SOURCE_BROWSER .*|SOURCE_BROWSER = YES|' Doxygen Doxyfile
+          sed -i 's|^SOURCE_BROWSER .*|SOURCE_BROWSER = YES|' Doxyfile
           sed -i 's|^INLINE_SOURCES .*|INLINE_SOURCES = YES|' Doxyfile
 
       - name: Generate Doxygen Documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,19 +28,19 @@ jobs:
 
       - name: Configure Doxyfile
         run: |
-          sed -i 's|^OUTPUT_DIRECTORY .*|OUTPUT_DIRECTORY = . |' Doxyfile
-          sed -i 's|^# GENERATE_HTML .*|GENERATE_HTML = YES|' Doxyfile
-          sed -i 's|^# INPUT .*|INPUT = ./|' Doxyfile
+          sed -i 's|^OUTPUT_DIRECTORY .*|OUTPUT_DIRECTORY = .|' Doxyfile
+          sed -i 's|^INPUT .*|INPUT = ./|' Doxyfile
           sed -i 's|^RECURSIVE .*|RECURSIVE = YES|' Doxyfile
-          sed -i 's|^# EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
-          sed -i 's|^# EXTRACT_PRIVATE .*|EXTRACT_PRIVATE = YES|' Doxyfile
-          sed -i 's|^# EXTRACT_STATIC .*|EXTRACT_STATIC = YES|' Doxyfile
-          sed -i 's|^# HIDE_UNDOC_MEMBERS .*|HIDE_UNDOC_MEMBERS = NO|' Doxyfile
-          sed -i 's|^# OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
-          sed -i 's|^# FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
-          sed -i 's|^# EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile
+          sed -i 's|^GENERATE_HTML .*|GENERATE_HTML = YES|' Doxyfile
+          sed -i 's|^EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
+          sed -i 's|^EXTRACT_PRIVATE .*|EXTRACT_PRIVATE = YES|' Doxyfile
+          sed -i 's|^EXTRACT_STATIC .*|EXTRACT_STATIC = YES|' Doxyfile
+          sed -i 's|^HIDE_UNDOC_MEMBERS .*|HIDE_UNDOC_MEMBERS = NO|' Doxyfile
+          sed -i 's|^OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
+          sed -i 's|^FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
+          sed -i 's|^EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile
           sed -i 's|^SOURCE_BROWSER .*|SOURCE_BROWSER = YES|' Doxyfile
-          sed -i 's|^INLINE_SOURCES .*|INLINE_SOURCES = YES|' Doxyfile
+          sed -i 's|^INLINE_SOURCES .*|INLINE_SOURCES = NO|' Doxyfile
 
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,7 @@ jobs:
           sed -i 's|^# EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
           sed -i 's|^# EXTRACT_PRIVATE .*|EXTRACT_PRIVATE = YES|' Doxyfile
           sed -i 's|^# EXTRACT_STATIC .*|EXTRACT_STATIC = YES|' Doxyfile
+          sed -i 's|^# HIDE_UNDOC_MEMBERS .*|HIDE_UNDOC_MEMBERS = NO|' Doxyfile
           sed -i 's|^# OPTIMIZE_OUTPUT_FOR_CSHARP .*|OPTIMIZE_OUTPUT_FOR_CSHARP = YES|' Doxyfile
           sed -i 's|^# FILE_PATTERNS .*|FILE_PATTERNS = *.cs|' Doxyfile
           sed -i 's|^# EXTENSION_MAPPING .*|EXTENSION_MAPPING = cs=C#|' Doxyfile

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,6 +29,7 @@ jobs:
           sed -i 's|^# GENERATE_HTML .*|GENERATE_HTML = YES|' Doxyfile
           sed -i 's|^# INPUT .*|INPUT = ./|' Doxyfile
           sed -i 's|^RECURSIVE .*|RECURSIVE = YES|' Doxyfile
+          sed -i 's|^# EXTRACT_ALL .*|EXTRACT_ALL = YES|' Doxyfile
 
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile

--- a/SensorApp/SensorApp.Api/Endpoints/AuthEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/AuthEndpoints.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
-using SensorApp.Core.Services.Auth;
+﻿using SensorApp.Core.Services.Auth;
 using SensorApp.Shared.Dtos;
 
 namespace SensorApp.Api.Endpoints;

--- a/SensorApp/SensorApp.Api/Endpoints/MeasurandEndpoints.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/MeasurandEndpoints.cs
@@ -7,6 +7,7 @@ namespace SensorApp.Api.Endpoints;
 
 /// <summary>
 /// Defines API endpoints related to measurand data retrieval for sensors.
+/// Access is restricted to users with Environmental Scientist or Administrator roles.
 /// </summary>
 public static class MeasurandEndpoints
 {

--- a/SensorApp/SensorApp.Api/Endpoints/MeasurementEndpoint.cs
+++ b/SensorApp/SensorApp.Api/Endpoints/MeasurementEndpoint.cs
@@ -7,6 +7,7 @@ namespace SensorApp.Api.Endpoints;
 
 /// <summary>
 /// Defines API endpoints for retrieving measurement data from the system.
+/// Access is restricted to users with Environmental Scientist or Administrator roles.
 /// </summary>
 public static class MeasurementEndpoint
 {

--- a/SensorApp/SensorApp.Api/Swagger/AddSwaggerWithJwt.cs
+++ b/SensorApp/SensorApp.Api/Swagger/AddSwaggerWithJwt.cs
@@ -2,8 +2,16 @@
 
 namespace SensorApp.Api.Swagger;
 
+/// <summary>
+/// Provides extension methods for configuring Swagger with JWT authentication support.
+/// </summary>
 public static class SwaggerConfiguration
 {
+    /// <summary>
+    /// Adds Swagger generation services to the application with JWT Bearer token security configured.
+    /// This enables API documentation and testing through Swagger UI, requiring JWT tokens for authorized endpoints.
+    /// </summary>
+    /// <param name="services">The service collection to which the Swagger services will be added.</param>
     public static void AddSwaggerWithJwt(this IServiceCollection services)
     {
         services.AddSwaggerGen(options =>

--- a/SensorApp/SensorApp.Core/Services/Auth/AuthService.cs
+++ b/SensorApp/SensorApp.Core/Services/Auth/AuthService.cs
@@ -14,16 +14,6 @@ public class AuthService : IAuthService
 
     public AuthService(UserManager<IdentityUser> users, ITokenService tokenService) => (_users, _tokenService) = (users, tokenService);
 
-
-    /// <summary>
-    /// Authenticates a user based on provided login credentials.
-    /// If successful, generates a JWT token and returns basic user information.
-    /// </summary>
-    /// <param name="login">The login credentials entered by the user.</param>
-    /// <returns>
-    /// An <see cref="AuthResponseDto"/> containing the user ID, username, and JWT token if authentication succeeds;
-    /// otherwise, <c>null</c> if authentication fails.
-    /// </returns>
     public async Task<AuthResponseDto?> AuthenticateAsync(LoginDto login)
     {
         var user = await _users.FindByNameAsync(login.Username);

--- a/SensorApp/SensorApp.Core/Services/Auth/IAuthService.cs
+++ b/SensorApp/SensorApp.Core/Services/Auth/IAuthService.cs
@@ -3,18 +3,17 @@
 namespace SensorApp.Core.Services.Auth;
 
 /// <summary>
-/// Interface that defines authentication services for the application,
-/// including user login and retrieval of authentication tokens.
+/// Defines authentication-related operations for users.
 /// </summary>
 public interface IAuthService
 {
-    // <summary>
-    /// Authenticates a user based on provided login credentials.
+    /// <summary>
+    /// Authenticates a user using their login credentials.
     /// </summary>
-    /// <param name="login">The login details containing username and password.</param>
+    /// <param name="login">An object containing the user's username and password.</param>
     /// <returns>
-    /// An <see cref="AuthResponseDto"/> containing authentication result details and a token if successful;
-    /// otherwise, null if authentication fails.
+    /// An <see cref="AuthResponseDto"/> containing user details and a JWT token if authentication succeeds;
+    /// otherwise, <c>null</c> if the credentials are invalid.
     /// </returns>
     Task<AuthResponseDto?> AuthenticateAsync(LoginDto login);
 }

--- a/SensorApp/SensorApp.Core/Services/Auth/ITokenService.cs
+++ b/SensorApp/SensorApp.Core/Services/Auth/ITokenService.cs
@@ -7,5 +7,13 @@ namespace SensorApp.Core.Services.Auth;
 /// </summary>
 public interface ITokenService
 {
+    /// <summary>
+    /// Generates a signed JWT token for an authenticated user.
+    /// The token includes the user's ID, email address, and all assigned role claims.
+    /// </summary>
+    /// <param name="user">The authenticated <see cref="IdentityUser"/> object.</param>
+    /// <param name="roles">A list of roles associated with the user.</param>
+    /// <returns>A signed JWT token string containing the user's claims.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the user is null.</exception>
     string GenerateToken(IdentityUser user, IList<string> roles);
 }

--- a/SensorApp/SensorApp.Core/Services/Auth/TokenService.cs
+++ b/SensorApp/SensorApp.Core/Services/Auth/TokenService.cs
@@ -16,14 +16,6 @@ public class TokenService(IOptions<JwtSettings> options) : ITokenService
 {
     private readonly JwtSettings _jwtSettings = options.Value;
 
-    /// <summary>
-    /// Generates a signed JWT token for an authenticated user.
-    /// The token includes the user's ID, email address, and all assigned role claims.
-    /// </summary>
-    /// <param name="user">The authenticated <see cref="IdentityUser"/> object.</param>
-    /// <param name="roles">A list of roles associated with the user.</param>
-    /// <returns>A signed JWT token string containing the user's claims.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if the user is null.</exception>
     public string GenerateToken(IdentityUser user, IList<string> roles)
     {
         if (user == null)

--- a/SensorApp/SensorApp.Maui/App.xaml.cs
+++ b/SensorApp/SensorApp.Maui/App.xaml.cs
@@ -1,10 +1,22 @@
 ﻿using SensorApp.Shared.Models;
 
 namespace SensorApp.Maui;
+
+/// <summary>
+/// The main entry point of the application.
+/// Sets up global application state and initializes the main navigation shell.
+/// </summary>
 public partial class App : Application
 {
+    /// <summary>
+    /// Holds the authenticated user's information during the application's lifecycle.
+    /// </summary>
     public static UserInfo UserInfo { get; set; } = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="App"/> class.
+    /// Sets up the main navigation structure of the application.
+    /// </summary>
     public App()
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/AppShell.xaml.cs
+++ b/SensorApp/SensorApp.Maui/AppShell.xaml.cs
@@ -2,8 +2,16 @@
 
 namespace SensorApp.Maui;
 
+/// <summary>
+/// Defines the application's main navigation structure using Shell.
+/// Registers all page routes for navigation throughout the app.
+/// </summary>
 public partial class AppShell : Shell
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppShell"/> class.
+    /// Sets up all page routes for the application.
+    /// </summary>
     public AppShell()
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Helpers/Charting/MicrochartsChartFactory.cs
+++ b/SensorApp/SensorApp.Maui/Helpers/Charting/MicrochartsChartFactory.cs
@@ -14,12 +14,6 @@ public class MicrochartsChartFactory : IChartFactory
     private readonly SKColor _lineColor = SKColors.DeepSkyBlue;
     private readonly SKColor _barColor = SKColors.Purple;
 
-    /// <summary>
-    /// Creates a LineChart based on the provided measurement data.
-    /// Each point represents a measurement at a specific timestamp.
-    /// </summary>
-    /// <param name="data">The collection of measurement values to plot.</param>
-    /// <returns>A configured <see cref="LineChart"/> representing the data.</returns>
     public LineChart CreateLineChart(IEnumerable<MeasurementModel> data)
     {
         var entries = data.Select(m => new ChartEntry(m.Value)
@@ -39,12 +33,6 @@ public class MicrochartsChartFactory : IChartFactory
         };
     }
 
-    /// <summary>
-    /// Creates a BarChart based on the provided measurement data.
-    /// Each bar represents a measurement value, grouped by date.
-    /// </summary>
-    /// <param name="data">The collection of measurement values to display.</param>
-    /// <returns>A configured <see cref="BarChart"/> representing the data.</returns>
     public BarChart CreateBarChart(IEnumerable<MeasurementModel> data)
     {
         var entries = data.Select(m => new ChartEntry(m.Value)

--- a/SensorApp/SensorApp.Maui/Helpers/MenuRoles/MenuBuilder.cs
+++ b/SensorApp/SensorApp.Maui/Helpers/MenuRoles/MenuBuilder.cs
@@ -1,21 +1,33 @@
 ﻿using SensorApp.Maui.Views.Controls;
 using SensorApp.Maui.Views.Pages;
-using SensorApp.Shared.Enums;
 using SensorApp.Shared.Factories;
 using SensorApp.Shared.Interfaces;
 using SensorApp.Shared.Models;
 
 namespace SensorApp.Maui.Helpers.MenuRoles;
 
-public class MenuBuilder(IServiceProvider serviceProvider) : IMenuBuilder
+/// <summary>
+/// Builds the application's navigation menu dynamically based on the user's role.
+/// Utilizes the <see cref="IMenuFactory"/> to generate role-specific menu items and attaches them to the app shell.
+/// </summary>
+public class MenuBuilder : IMenuBuilder
 {
-    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
-    /// Builds the application's navigation menu dynamically based on the user's role.
-    /// Works with the <see cref="IMenuFactory"/> to get the user's menu base on their specific role, and converts them to UI elements that are shown in the app Shell.
+    /// Initializes a new instance of the <see cref="MenuBuilder"/> class.
     /// </summary>
-    /// <param name="userInfo">Information about the currently logged-in user in the app.</param>
+    /// <param name="serviceProvider">The application's service provider for resolving page instances.</param>
+    public MenuBuilder(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>
+    /// Builds the navigation menu based on the authenticated user's role.
+    /// Clears existing shell items, creates new flyout menu items, and adds a logout item.
+    /// </summary>
+    /// <param name="userInfo">Information about the currently authenticated user, including their role.</param>
     public void BuildMenu(UserInfo userInfo)
     {
         if (userInfo is null)
@@ -38,8 +50,11 @@ public class MenuBuilder(IServiceProvider serviceProvider) : IMenuBuilder
     }
 
     /// <summary>
-    /// Creates a <see cref="FlyoutItem"/> for the given menu item.
+    /// Creates a <see cref="FlyoutItem"/> for a given application menu item.
+    /// Dynamically resolves the associated page type from the service provider.
     /// </summary>
+    /// <param name="item">The application menu item to convert into a flyout item.</param>
+    /// <returns>A configured <see cref="FlyoutItem"/> for the Shell menu.</returns>
     private FlyoutItem CreateFlyoutItem(AppMenuItem item)
     {
         var pageType = Type.GetType($"SensorApp.Maui.Views.Pages.{item.Route}") ?? throw new InvalidOperationException($"Page type '{item.Route}' not found.");
@@ -62,7 +77,8 @@ public class MenuBuilder(IServiceProvider serviceProvider) : IMenuBuilder
     }
 
     /// <summary>
-    /// Adds a fixed Logout item to the end of the menu.
+    /// Adds a fixed logout option to the Shell menu,
+    /// allowing the user to sign out from the application.
     /// </summary>
     private void AddLogoutItem()
     {

--- a/SensorApp/SensorApp.Maui/Interfaces/IChartFactory.cs
+++ b/SensorApp/SensorApp.Maui/Interfaces/IChartFactory.cs
@@ -3,8 +3,23 @@ using SensorApp.Shared.Models;
 
 namespace SensorApp.Maui.Interfaces;
 
+/// <summary>
+/// Defines a factory for creating chart objects based on measurement data.
+/// </summary>
 public interface IChartFactory
 {
+    /// <summary>
+    /// Creates a LineChart from a collection of measurement data.
+    /// Each point in the chart represents a measurement at a specific timestamp.
+    /// </summary>
+    /// <param name="data">The collection of measurement values to plot.</param>
+    /// <returns>A configured <see cref="LineChart"/> representing the measurement data.</returns>
     LineChart CreateLineChart(IEnumerable<MeasurementModel> data);
+    /// <summary>
+    /// Creates a BarChart from a collection of measurement data.
+    /// Each bar represents an individual measurement value, grouped by date.
+    /// </summary>
+    /// <param name="data">The collection of measurement values to display.</param>
+    /// <returns>A configured <see cref="BarChart"/> representing the measurement data.</returns>
     BarChart CreateBarChart(IEnumerable<MeasurementModel> data);
 }

--- a/SensorApp/SensorApp.Maui/MainPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/MainPage.xaml.cs
@@ -1,7 +1,13 @@
 ﻿namespace SensorApp.Maui;
 
+/// <summary>
+/// Represents the main landing page of the application after successful login or navigation.
+/// </summary>
 public partial class MainPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainPage"/> class.
+    /// </summary>
     public MainPage()
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/ViewModels/AdminUsersViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/AdminUsersViewModel.cs
@@ -11,11 +11,24 @@ namespace SensorApp.Maui.ViewModels;
 /// <summary>
 /// ViewModel for managing admin users, including loading, creating, editing, and deleting users.
 /// </summary>
-public partial class AdminUsersViewModel(IAdminService adminService, ILogger<AdminUsersViewModel> logger, ITokenProvider tokenProvider) : BaseViewModel
+public partial class AdminUsersViewModel : BaseViewModel
 {
-    private readonly IAdminService _adminService = adminService;
-    private readonly ILogger<AdminUsersViewModel> _logger = logger;
-    private readonly ITokenProvider _tokenProvider = tokenProvider;
+    private readonly IAdminService _adminService;
+    private readonly ILogger<AdminUsersViewModel> _logger;
+    private readonly ITokenProvider _tokenProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdminUsersViewModel"/> class.
+    /// </summary>
+    /// <param name="adminService">Service for admin-related operations.</param>
+    /// <param name="logger">Logger for recording application events.</param>
+    /// <param name="tokenProvider">Provider for retrieving authentication tokens.</param>
+    public AdminUsersViewModel(IAdminService adminService, ILogger<AdminUsersViewModel> logger, ITokenProvider tokenProvider)
+    {
+        _adminService = adminService;
+        _logger = logger;
+        _tokenProvider = tokenProvider;
+    }
 
     [ObservableProperty]
     private ObservableCollection<UserWithRoleDto> users = new();

--- a/SensorApp/SensorApp.Maui/ViewModels/EditUserViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/EditUserViewModel.cs
@@ -10,12 +10,20 @@ using System.Text.RegularExpressions;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for editing an existing user's details, including username, email, role, and password.
+/// </summary>
 [QueryProperty(nameof(UserId), "UserId")]
 public partial class EditUserViewModel : BaseViewModel
 {
     private readonly IAdminService _adminService;
     private readonly ITokenProvider _tokenProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EditUserViewModel"/> class.
+    /// </summary>
+    /// <param name="adminService">Service to perform admin operations like user management.</param>
+    /// <param name="tokenProvider">Provider to retrieve the current authentication token.</param>
     public EditUserViewModel(IAdminService adminService, ITokenProvider tokenProvider)
     {
         _adminService = adminService;
@@ -41,6 +49,12 @@ public partial class EditUserViewModel : BaseViewModel
     public ObservableCollection<UserRole> Roles { get; }
     private string? _currentUserId;
 
+
+    /// <summary>
+    /// Called automatically when <see cref="UserId"/> changes.
+    /// Triggers loading of the user's existing details.
+    /// </summary>
+    /// <param name="value">The new UserId value.</param>
     partial void OnUserIdChanged(string value) => _ = LoadUserAsync();
 
     /// <summary>

--- a/SensorApp/SensorApp.Maui/ViewModels/HistoricalDataViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/HistoricalDataViewModel.cs
@@ -5,11 +5,14 @@ using SensorApp.Maui.Interfaces;
 using SensorApp.Maui.Utils;
 using SensorApp.Shared.Interfaces;
 using SensorApp.Shared.Models;
-using SensorApp.Shared.Services;
 using System.Collections.ObjectModel;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel responsible for loading, managing, and displaying historical measurement data,
+/// including generating charts and basic statistics.
+/// </summary>
 public partial class HistoricalDataViewModel : BaseViewModel
 {
     readonly IMeasurementService _measurementService;
@@ -18,6 +21,14 @@ public partial class HistoricalDataViewModel : BaseViewModel
     readonly ISensorApiService _sensorService;
     readonly IChartFactory _chartFactory;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistoricalDataViewModel"/> class.
+    /// </summary>
+    /// <param name="measurementService">Service for retrieving measurement data.</param>
+    /// <param name="tokenProvider">Service for retrieving authentication tokens.</param>
+    /// <param name="sensorService">Service for retrieving sensor information.</param>
+    /// <param name="measurandService">Service for retrieving measurand types.</param>
+    /// <param name="chartFactory">Factory for creating charts.</param>
     public HistoricalDataViewModel(IMeasurementService measurementService, ITokenProvider tokenProvider, ISensorApiService sensorService, IMeasurandService measurandService, IChartFactory chartFactory)
     {
         _measurementService = measurementService;

--- a/SensorApp/SensorApp.Maui/ViewModels/LoadingPageViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/LoadingPageViewModel.cs
@@ -7,11 +7,20 @@ using System.Security.Claims;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for the loading page that verifies user authentication and navigates accordingly.
+/// </summary>
 public partial class LoadingPageViewModel : BaseViewModel
 {
     private readonly IMenuBuilder _menuBuilder;
     private readonly ITokenProvider _tokenProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoadingPageViewModel"/> class.
+    /// Starts the authentication validation process.
+    /// </summary>
+    /// <param name="menuBuilder">Service responsible for dynamically building the application menu based on user roles.</param>
+    /// <param name="tokenProvider">Service for retrieving and managing authentication tokens.</param>
     public LoadingPageViewModel(IMenuBuilder menuBuilder, ITokenProvider tokenProvider)
     {
         _menuBuilder = menuBuilder;

--- a/SensorApp/SensorApp.Maui/ViewModels/LoginViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/LoginViewModel.cs
@@ -9,10 +9,25 @@ using System.Security.Claims;
 
 namespace SensorApp.Maui.ViewModels;
 
-public partial class LoginViewModel(IAuthService authService, IMenuBuilder menuBuilder) : BaseViewModel
+/// <summary>
+/// ViewModel responsible for handling user login functionality,
+/// including authentication, token parsing, and navigation after login.
+/// </summary>
+public partial class LoginViewModel : BaseViewModel
 {
-    private readonly IAuthService _authService = authService;
-    private readonly IMenuBuilder _menuBuilder = menuBuilder;
+    private readonly IAuthService _authService;
+    private readonly IMenuBuilder _menuBuilder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginViewModel"/> class.
+    /// </summary>
+    /// <param name="authService">Service to authenticate user credentials.</param>
+    /// <param name="menuBuilder">Service to build the application menu based on user roles.</param>
+    public LoginViewModel(IAuthService authService, IMenuBuilder menuBuilder)
+    {
+        _authService = authService;
+        _menuBuilder = menuBuilder;
+    }
 
 
     [ObservableProperty]
@@ -72,10 +87,12 @@ public partial class LoginViewModel(IAuthService authService, IMenuBuilder menuB
     }
 
     /// <summary>
-    /// Parses the JWT token and extracts user information.
+    /// Parses a JWT token and extracts the user information such as email and role.
     /// </summary>
-    /// <param name="token">The JWT token string.</param>
-    /// <returns>Parsed <see cref="UserInfo"/> object or null if parsing fails.</returns>
+    /// <param name="token">The JWT token string to parse.</param>
+    /// <returns>
+    /// A <see cref="UserInfo"/> object if parsing is successful; otherwise, <c>null</c>.
+    /// </returns>
     private UserInfo? ParseToken(string token)
     {
         try

--- a/SensorApp/SensorApp.Maui/ViewModels/NewUserViewModel.cs
+++ b/SensorApp/SensorApp.Maui/ViewModels/NewUserViewModel.cs
@@ -9,11 +9,20 @@ using System.Text.RegularExpressions;
 
 namespace SensorApp.Maui.ViewModels;
 
+/// <summary>
+/// ViewModel for creating new users. Handles input validation, user creation requests,
+/// and displays feedback to the user.
+/// </summary>
 public partial class NewUserViewModel : BaseViewModel
 {
     private readonly IAdminService _adminService;
     private readonly ITokenProvider _tokenProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewUserViewModel"/> class.
+    /// </summary>
+    /// <param name="adminService">Service for managing admin-related operations.</param>
+    /// <param name="tokenProvider">Service for retrieving authentication tokens.</param>
     public NewUserViewModel(IAdminService adminService, ITokenProvider tokenProvider)
     {
         _adminService = adminService;
@@ -112,8 +121,9 @@ public partial class NewUserViewModel : BaseViewModel
     }
 
     /// <summary>
-    /// Validates if required fields are filled.
+    /// Validates that all required input fields are filled.
     /// </summary>
+    /// <returns>True if all required fields are filled; otherwise, false.</returns>
     private bool AreFieldsFilled()
     {
         return !string.IsNullOrWhiteSpace(Username) && !string.IsNullOrWhiteSpace(Email) && !string.IsNullOrWhiteSpace(Password);

--- a/SensorApp/SensorApp.Maui/Views/Pages/AdminUsersPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/AdminUsersPage.xaml.cs
@@ -2,10 +2,17 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page for managing application users from an admin perspective.
+/// Displays a list of users, and provides options to create, edit, or delete users.
+/// </summary>
 public partial class AdminUsersPage : ContentPage
 {
     private readonly AdminUsersViewModel viewModel;
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdminUsersPage"/> class.
+    /// </summary>
+    /// <param name="vm">The view model responsible for managing users and actions on this page.</param>
     public AdminUsersPage(AdminUsersViewModel vm)
     {
         InitializeComponent();
@@ -13,6 +20,10 @@ public partial class AdminUsersPage : ContentPage
         BindingContext = viewModel;
     }
 
+    /// <summary>
+    /// Called automatically when the page appears.
+    /// Triggers loading of the user list by calling the view model.
+    /// </summary>
     protected override async void OnAppearing()
     {
         base.OnAppearing();

--- a/SensorApp/SensorApp.Maui/Views/Pages/EditUserPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/EditUserPage.xaml.cs
@@ -2,8 +2,16 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page for editing an existing user's details (such as username, email, role, and password).
+/// Binds to an instance of <see cref="EditUserViewModel"/> for logic and data operations.
+/// </summary>
 public partial class EditUserPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EditUserPage"/> class.
+    /// </summary>
+    /// <param name="viewModel">The view model responsible for handling the edit user functionality.</param>
     public EditUserPage(EditUserViewModel viewModel)
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Views/Pages/HistoricalDataPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/HistoricalDataPage.xaml.cs
@@ -2,14 +2,26 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page for displaying historical measurement data, charts, and statistics.
+/// Binds to <see cref="HistoricalDataViewModel"/> for sensor selection, filtering, and data visualization.
+/// </summary>
 public partial class HistoricalDataPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HistoricalDataPage"/> class.
+    /// </summary>
+    /// <param name="vm">The view model responsible for handling historical data operations.</param>
     public HistoricalDataPage(HistoricalDataViewModel vm)
     {
         InitializeComponent();
         BindingContext = vm;
     }
 
+    /// <summary>
+    /// Called when the page appears on screen.
+    /// Loads available sensor options and measurement data by invoking the view model's methods.
+    /// </summary>
     protected override async void OnAppearing()
     {
         base.OnAppearing();

--- a/SensorApp/SensorApp.Maui/Views/Pages/LoadingPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/LoadingPage.xaml.cs
@@ -2,8 +2,16 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page displayed while the application checks user authentication status.
+/// Binds to <see cref="LoadingPageViewModel"/> which handles token validation and navigation logic.
+/// </summary>
 public partial class LoadingPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoadingPage"/> class.
+    /// </summary>
+    /// <param name="viewModel">The view model responsible for handling authentication checks during the loading phase.</param>
     public LoadingPage(LoadingPageViewModel viewModel)
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Views/Pages/LoginPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/LoginPage.xaml.cs
@@ -2,8 +2,16 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page for allowing users to log into the application.
+/// Binds to <see cref="LoginViewModel"/> which handles user input, authentication, and navigation after login.
+/// </summary>
 public partial class LoginPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginPage"/> class.
+    /// </summary>
+    /// <param name="loginViewModel">The view model responsible for managing login logic and authentication flow.</param>
     public LoginPage(LoginViewModel loginViewModel)
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Maui/Views/Pages/LogoutPage.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/LogoutPage.cs
@@ -2,10 +2,18 @@
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page responsible for logging the user out of the application.
+/// Binds to <see cref="LogoutViewModel"/> which handles the logout process and navigation.
+/// </summary>
 public partial class LogoutPage : ContentPage
 {
     private readonly LogoutViewModel _logoutViewModel;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LogoutPage"/> class.
+    /// </summary>
+    /// <param name="logoutViewModel">The view model responsible for managing the logout process.</param>
     public LogoutPage(LogoutViewModel logoutViewModel)
     {
 
@@ -16,6 +24,10 @@ public partial class LogoutPage : ContentPage
 
     }
 
+    /// <summary>
+    /// Called when the page appears.
+    /// Automatically triggers the logout process through the view model.
+    /// </summary>
     protected override async void OnAppearing()
     {
         base.OnAppearing();

--- a/SensorApp/SensorApp.Maui/Views/Pages/NewUserPage.xaml.cs
+++ b/SensorApp/SensorApp.Maui/Views/Pages/NewUserPage.xaml.cs
@@ -2,8 +2,16 @@ using SensorApp.Maui.ViewModels;
 
 namespace SensorApp.Maui.Views.Pages;
 
+/// <summary>
+/// Page for creating a new user within the application.
+/// Binds to <see cref="NewUserViewModel"/> to handle input validation and user creation logic.
+/// </summary>
 public partial class NewUserPage : ContentPage
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewUserPage"/> class.
+    /// </summary>
+    /// <param name="vm">The view model responsible for managing new user creation operations.</param>
     public NewUserPage(NewUserViewModel vm)
     {
         InitializeComponent();

--- a/SensorApp/SensorApp.Shared/Dtos/Admin/CreateUserDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Admin/CreateUserDto.cs
@@ -3,7 +3,8 @@
 namespace SensorApp.Shared.Dtos.Admin;
 
 /// <summary>
-/// Payload used by an administrator to create a new user.
+/// Payload used by an administrator to create a new user account.
+/// All fields are required for user creation.
 /// </summary>
 public class CreateUserDto
 {

--- a/SensorApp/SensorApp.Shared/Dtos/Admin/UpdateUserDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Admin/UpdateUserDto.cs
@@ -2,6 +2,10 @@
 
 namespace SensorApp.Shared.Dtos.Admin;
 
+/// <summary>
+/// Payload used by an administrator to update an existing user's details.
+/// Fields are optional, allowing partial updates.
+/// </summary>
 public class UpdateUserDto
 {
     public string? Username { get; set; }

--- a/SensorApp/SensorApp.Shared/Dtos/Admin/UserWithRoleDto.cs
+++ b/SensorApp/SensorApp.Shared/Dtos/Admin/UserWithRoleDto.cs
@@ -3,8 +3,8 @@
 namespace SensorApp.Shared.Dtos.Admin;
 
 /// <summary>
-/// Data Transfer Object representing a user and their associated role.
-/// This is used in the Admin section of the app (AdminUsersViewModel) to populate the user management table in the frontend.
+/// Data Transfer Object representing a user along with their assigned role.
+/// Used to populate the admin user management tables in the application.
 /// </summary>
 public class UserWithRoleDto
 {

--- a/SensorApp/SensorApp.Shared/Factories/EnvironmentalMenuFactory.cs
+++ b/SensorApp/SensorApp.Shared/Factories/EnvironmentalMenuFactory.cs
@@ -3,12 +3,19 @@ using SensorApp.Shared.Models;
 
 namespace SensorApp.Shared.Factories;
 
+/// <summary>
+/// Factory class responsible for creating the navigation menu items 
+/// that are available to environmental Scientist users within the application.
+/// </summary>
 public class EnvironmentalMenuFactory : IMenuFactory
 {
     /// <summary>
-    /// Creates a collection of menu items specific to Environmental Scientist users that will appear on the app's side menu
+    /// Creates a collection of menu items specific to Environmental Scientist users
+    /// that will appear in the app's side menu.
     /// </summary>
-    /// <returns>A list of <see cref="AppMenuItem"/> representing Environmental Scientist navigation options.</returns>
+    /// <returns>
+    /// A list of <see cref="AppMenuItem"/> representing the Environmental Scientist's navigation options.
+    /// </returns>
     public IEnumerable<AppMenuItem> CreateMenu()
     {
         return

--- a/SensorApp/SensorApp.Shared/Factories/OperationsMenuFactory.cs
+++ b/SensorApp/SensorApp.Shared/Factories/OperationsMenuFactory.cs
@@ -3,6 +3,10 @@ using SensorApp.Shared.Models;
 
 namespace SensorApp.Shared.Factories;
 
+/// <summary>
+/// Factory class responsible for creating the navigation menu items 
+/// that are available to Operations Manager users within the application.
+/// </summary>
 public class OperationsMenuFactory : IMenuFactory
 {
     /// <summary>

--- a/SensorApp/SensorApp.Shared/Interfaces/IAdminService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IAdminService.cs
@@ -3,13 +3,51 @@
 namespace SensorApp.Shared.Interfaces;
 
 /// <summary>
-/// Interface defining administrative operations related to user management, such as creating, retrieving, updating, and deleting users.
+/// Defines administrative operations related to user management, such as creating, retrieving, updating, and deleting users via the API.
 /// </summary>
 public interface IAdminService
 {
+    /// <summary>
+    /// Retrieves the information of a specific user by their unique ID.
+    /// </summary>
+    /// <param name="token">The authentication token for authorization.</param>
+    /// <param name="userId">The ID of the user to retrieve.</param>
+    /// <returns>
+    /// A <see cref="UserWithRoleDto"/> containing the user's information if found; otherwise, <c>null</c>.
+    /// </returns>
     Task<UserWithRoleDto?> GetUserByIdAsync(string token, string userId);
+
+    /// <summary>
+    /// Retrieves all users registered in the system along with their assigned roles.
+    /// </summary>
+    /// <param name="token">The authentication token for authorization.</param>
+    /// <returns>
+    /// A list of <see cref="UserWithRoleDto"/> representing all users.
+    /// </returns>
     Task<List<UserWithRoleDto>> GetAllUsersAsync(string token);
+
+    /// <summary>
+    /// Adds a new user to the system.
+    /// </summary>
+    /// <param name="token">The authentication token for authorization.</param>
+    /// <param name="newUser">The information of the new user to create.</param>
+    /// <returns>True if the user was successfully created; otherwise, false.</returns>
     Task<bool> AddUserAsync(string token, CreateUserDto newUser);
+
+    /// <summary>
+    /// Deletes an existing user from the system by their user ID.
+    /// </summary>
+    /// <param name="token">The authentication token for authorization.</param>
+    /// <param name="userId">The ID of the user to delete.</param>
+    /// <returns>True if the user was successfully deleted; otherwise, false.</returns>
     Task<bool> DeleteUserAsync(string token, string userId);
+
+    /// <summary>
+    /// Updates the details of an existing user.
+    /// </summary>
+    /// <param name="token">The authentication token for authorization.</param>
+    /// <param name="userId">The ID of the user to update.</param>
+    /// <param name="updatedUser">The updated user information.</param>
+    /// <returns>True if the user was successfully updated; otherwise, false.</returns>
     Task<bool> UpdateUserAsync(string token, string userId, UpdateUserDto updatedUser);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IAuthService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IAuthService.cs
@@ -8,6 +8,18 @@ namespace SensorApp.Shared.Interfaces;
 /// </summary>
 public interface IAuthService
 {
+    /// <summary>
+    /// Attempts to authenticate a user by sending login credentials to the backend.
+    /// </summary>
+    /// <param name="loginDto">The user's login credentials (username and password).</param>
+    /// <returns>
+    /// An <see cref="AuthResponseDto"/> containing authentication results, including a JWT token if successful.
+    /// </returns>
     Task<AuthResponseDto> Login(LoginDto loginDto);
+
+    /// <summary>
+    /// Gets a short status message about the most recent authentication attempt.
+    /// Example messages include "Login Successful" or "Attempt failed".
+    /// </summary>
     string StatusMessage { get; }
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IMeasurandService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IMeasurandService.cs
@@ -6,5 +6,14 @@ namespace SensorApp.Shared.Interfaces;
 /// </summary>
 public interface IMeasurandService
 {
+    /// <summary>
+    /// Retrieves a list of measurands available for a specific sensor.
+    /// </summary>
+    /// <param name="token">Authentication token required to authorize the request.</param>
+    /// <param name="sensorId">The unique identifier of the sensor whose measurands are requested.</param>
+    /// <returns>
+    /// A list of <see cref="MeasurandModel"/> representing the measurable properties for the specified sensor.
+    /// If no measurands are found or the request fails, an empty list is returned.
+    /// </returns>
     Task<List<MeasurandModel>> GetMeasurandsAsync(string token, int sensorId);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IMeasurementService.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IMeasurementService.cs
@@ -6,5 +6,18 @@ namespace SensorApp.Shared.Interfaces;
 /// </summary>
 public interface IMeasurementService
 {
+    /// <summary>
+    /// Asynchronously retrieves a list of measurements from the API.
+    /// Supports optional filters by sensor ID, measurand ID, and a specific time range.
+    /// </summary>
+    /// <param name="sensorId">Optional sensor ID to filter measurements for a specific sensor.</param>
+    /// <param name="measurandId">Optional measurand (measurement type) ID to filter by specific data type.</param>
+    /// <param name="from">Optional start date to filter measurements recorded after this time.</param>
+    /// <param name="to">Optional end date to filter measurements recorded before this time.</param>
+    /// <param name="token">Authentication token required for authorized API access.</param>
+    /// <returns>
+    /// A read-only list of <see cref="MeasurementModel"/> representing the measurements retrieved from the API.
+    /// Returns an empty list if no data is found or if the request fails.
+    /// </returns>
     Task<IReadOnlyList<MeasurementModel>> GetMeasurementsAsync(int? sensorId = null, int? measurandId = null, DateTime? from = null, DateTime? to = null, string token = "");
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/IMenuBuilder.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/IMenuBuilder.cs
@@ -2,11 +2,16 @@
 
 namespace SensorApp.Shared.Interfaces;
 
+/// <summary>
+/// Defines a contract for building the application's navigation menu dynamically based on user role.
+/// Typically called after user authentication is validated.
+/// </summary>
 public interface IMenuBuilder
 {
     /// <summary>
-    /// This is the main entry point for menu generation. Called in LoginViewModel or LoadingPageViewModel after login/token validation.
+    /// Generates and configures the application's navigation menu according to the authenticated user's role.
+    /// This method is called after login or token validation in the <see cref="LoginViewModel"/> or <see cref="LoadingPageViewModel"/>.
     /// </summary>
-    /// <param name="userInfo">The authenticated user's info, including role and username.</param>
+    /// <param name="userInfo">Information about the authenticated user, including role and username.</param>
     void BuildMenu(UserInfo userInfo);
 }

--- a/SensorApp/SensorApp.Shared/Interfaces/ITokenProvider.cs
+++ b/SensorApp/SensorApp.Shared/Interfaces/ITokenProvider.cs
@@ -1,9 +1,16 @@
 ﻿namespace SensorApp.Shared.Interfaces;
 
 /// <summary>
-/// Interface for retrieving authentication tokens needed for secure API communication.
+/// Defines a contract for retrieving authentication tokens used in secure API communication.
+/// Implementations should safely fetch tokens, typically from a secure storage.
 /// </summary>
 public interface ITokenProvider
 {
+    /// <summary>
+    /// Asynchronously retrieves the current authentication token.
+    /// </summary>
+    /// <returns>
+    /// A JWT token string if available; otherwise, <c>null</c> if no token is stored or retrieval fails.
+    /// </returns>
     Task<string?> GetTokenAsync();
 }

--- a/SensorApp/SensorApp.Shared/Models/BaseEntity.cs
+++ b/SensorApp/SensorApp.Shared/Models/BaseEntity.cs
@@ -1,5 +1,9 @@
 ﻿namespace SensorApp.Shared.Models;
 
+/// <summary>
+/// Provides a base class for all entities with a unique integer identifier.
+/// Intended to be inherited by other domain models in the application.
+/// </summary>
 public abstract class BaseEntity
 {
     public int Id { get; set; }

--- a/SensorApp/SensorApp.Shared/Services/AdminService.cs
+++ b/SensorApp/SensorApp.Shared/Services/AdminService.cs
@@ -8,68 +8,43 @@ namespace SensorApp.Shared.Services;
 /// Service class that handles administrative user operations,
 /// including retrieving, creating, updating, and deleting users via API calls.
 /// </summary>
-public class AdminService(HttpClient httpClient) : IAdminService
+public class AdminService : IAdminService
 {
-    private readonly HttpClient _httpClient = httpClient;
+    private readonly HttpClient _httpClient;
 
     /// <summary>
-    /// Retrieves a specific user's information, including their role, by their user ID.
+    /// Initializes a new instance of the <see cref="AdminService"/> class.
     /// </summary>
-    /// <param name="token">Authentication token required for authorization.</param>
-    /// <param name="userId">The unique ID of the user to retrieve.</param>
-    /// <returns>
-    /// A <see cref="UserWithRoleDto"/> representing the user's information, or null if not found.
-    /// </returns>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to communicate with the backend API.</param>
+    public AdminService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
     public async Task<UserWithRoleDto?> GetUserByIdAsync(string token, string userId)
     {
         var req = HttpRequestHelper.Create(HttpMethod.Get, $"/admin/users/{userId}", token);
         return await HttpRequestHelper.SendAsync<UserWithRoleDto>(_httpClient, req);
     }
 
-    /// <summary>
-    /// Retrieves a list of all users registered in the system along with their roles.
-    /// </summary>
-    /// <param name="token">Authentication token required for authorization.</param>
-    /// <returns>
-    /// A list of <see cref="UserWithRoleDto"/> representing all users.
-    /// </returns>
     public async Task<List<UserWithRoleDto>> GetAllUsersAsync(string token)
     {
         var request = HttpRequestHelper.Create(HttpMethod.Get, "/admin/users", token);
         return await HttpRequestHelper.SendAsync<List<UserWithRoleDto>>(_httpClient, request) ?? [];
     }
 
-    /// <summary>
-    /// Adds a new user to the system.
-    /// </summary>
-    /// <param name="token">Authentication token required for authorization.</param>
-    /// <param name="newUser">The details of the new user to be created.</param>
-    /// <returns>True if the user was successfully created; otherwise, false.</returns>
     public async Task<bool> AddUserAsync(string token, CreateUserDto newUser)
     {
         var request = HttpRequestHelper.Create(HttpMethod.Post, "/admin/users", token, newUser);
         return await HttpRequestHelper.SendAsync(_httpClient, request);
     }
 
-    /// <summary>
-    /// Deletes an existing user from the system by their user ID.
-    /// </summary>
-    /// <param name="token">Authentication token required for authorization.</param>
-    /// <param name="userId">The unique ID of the user to delete.</param>
-    /// <returns>True if the user was successfully deleted; otherwise, false.</returns
     public async Task<bool> DeleteUserAsync(string token, string userId)
     {
         var request = HttpRequestHelper.Create(HttpMethod.Delete, $"/admin/users/{userId}", token);
         return await HttpRequestHelper.SendAsync(_httpClient, request);
     }
 
-    /// <summary>
-    /// Updates an existing user's information.
-    /// </summary>
-    /// <param name="token">Authentication token required for authorization.</param>
-    /// <param name="userId">The unique ID of the user to update.</param>
-    /// <param name="updatedUser">The updated user details to apply.</param>
-    /// <returns>True if the user was successfully updated; otherwise, false.</returns>
     public async Task<bool> UpdateUserAsync(string token, string userId, UpdateUserDto updatedUser)
     {
         var req = HttpRequestHelper.Create(HttpMethod.Put, $"/admin/users/{userId}", token, updatedUser);

--- a/SensorApp/SensorApp.Shared/Services/AuthService.cs
+++ b/SensorApp/SensorApp.Shared/Services/AuthService.cs
@@ -4,19 +4,25 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Shared.Services;
 
-public class AuthService(HttpClient httpClient) : IAuthService
+/// <summary>
+/// Service responsible for handling user authentication by communicating with the backend API.
+/// Implements the <see cref="IAuthService"/> interface to perform login operations and track authentication status.
+/// </summary>
+public class AuthService : IAuthService
 {
-    private readonly HttpClient _httpClient = httpClient;
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthService"/> class.
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to send authentication requests.</param>
+    public AuthService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
 
     public string StatusMessage { get; private set; } = string.Empty;
 
-
-    /// <summary>
-    /// Sends the user's login credentials to the backend and processes the response
-    /// </summary>
-    /// <param name="loginDto">The login credentials entered by the user.</param>
-    /// <returns> a <see cref="AuthResponseDto"/> with JWT  and basic user info
-    /// </returns>
     public async Task<AuthResponseDto> Login(LoginDto loginDto)
     {
         try

--- a/SensorApp/SensorApp.Shared/Services/MeasurandService.cs
+++ b/SensorApp/SensorApp.Shared/Services/MeasurandService.cs
@@ -8,19 +8,19 @@ namespace SensorApp.Shared.Services;
 /// Service responsible for retrieving measurands (measurable properties)
 /// associated with a specific sensor by communicating with the backend API.
 /// </summary>
-public class MeasurandService(HttpClient httpClient) : IMeasurandService
+public class MeasurandService : IMeasurandService
 {
-    private readonly HttpClient _httpClient = httpClient;
+    private readonly HttpClient _httpClient;
 
     /// <summary>
-    /// Retrieves a list of measurands available for a specific sensor.
+    /// Initializes a new instance of the <see cref="MeasurandService"/> class.
     /// </summary>
-    /// <param name="token">Authentication token required to authorize the request.</param>
-    /// <param name="sensorId">The unique identifier of the sensor whose measurands are requested.</param>
-    /// <returns>
-    /// A list of <see cref="MeasurandModel"/> representing the measurable properties for the specified sensor.
-    /// If no measurands are found or the request fails, an empty list is returned.
-    /// </returns>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to communicate with the backend API.</param>
+    public MeasurandService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
     public async Task<List<MeasurandModel>> GetMeasurandsAsync(string token, int sensorId)
     {
         var request = HttpRequestHelper.Create(HttpMethod.Get, $"/sensors/{sensorId}/measurands", token);

--- a/SensorApp/SensorApp.Shared/Services/MeasurementService.cs
+++ b/SensorApp/SensorApp.Shared/Services/MeasurementService.cs
@@ -3,27 +3,24 @@ using SensorApp.Shared.Interfaces;
 using SensorApp.Shared.Models;
 
 namespace SensorApp.Shared.Services;
+
 /// <summary>
 /// Service responsible for retrieving measurement data from the backend API,
 /// supporting optional filtering by sensor, measurand, and date range.
 /// </summary>
-public class MeasurementService(HttpClient httpClient) : IMeasurementService
+public class MeasurementService : IMeasurementService
 {
-    private readonly HttpClient _httpClient = httpClient;
+    private readonly HttpClient _httpClient;
 
     /// <summary>
-    /// Asynchronously retrieves a list of measurements from the API.
-    /// Supports optional filters by sensor ID, measurand ID, and a specific time range.
+    /// Initializes a new instance of the <see cref="MeasurementService"/> class.
     /// </summary>
-    /// <param name="sensorId">Optional sensor ID to filter measurements for a specific sensor.</param>
-    /// <param name="measurandId">Optional measurand (measurement type) ID to filter by specific data type.</param>
-    /// <param name="from">Optional start date to filter measurements recorded after this time.</param>
-    /// <param name="to">Optional end date to filter measurements recorded before this time.</param>
-    /// <param name="token">Authentication token required for authorized API access.</param>
-    /// <returns>
-    /// A read-only list of <see cref="MeasurementModel"/> representing the measurements retrieved from the API.
-    /// Returns an empty list if no data is found or if the request fails.
-    /// </returns>
+    /// <param name="httpClient">The <see cref="HttpClient"/> used to communicate with the backend API.</param>
+    public MeasurementService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
     public async Task<IReadOnlyList<MeasurementModel>> GetMeasurementsAsync(int? sensorId = null, int? measurandId = null, DateTime? from = null, DateTime? to = null, string token = "")
     {
         var queryParameters = new List<string>();

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminCreateUsersEndpoint.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminCreateUsersEndpoint.cs
@@ -1,17 +1,21 @@
 ﻿using FluentAssertions;
 using SensorApp.Shared.Dtos.Admin;
 using SensorApp.Shared.Enums;
-using SensorApp.Tests.IntegrationTests.ApiEndpoints.AuthEndpoints;
 using SensorApp.Tests.IntegrationTests.ApiEndpoints.Helpers;
 using System.Net;
 using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.AdminEndpoints;
 
+/// <summary>
+/// Integration tests for the admin endpoint responsible for creating new users.
+/// Verifies that an administrator can successfully create users through the API.
+/// </summary>
 public class AdminCreateUsersEndpoint : IClassFixture<WebApplicationFactoryForTests>
 {
     private readonly HttpClient _client;
     private readonly TokenProvider _tokenProvider;
+
 
     public AdminCreateUsersEndpoint(WebApplicationFactoryForTests factory)
     {

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminDeleteUsersEndpoint.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminDeleteUsersEndpoint.cs
@@ -1,13 +1,15 @@
 ﻿using FluentAssertions;
 using SensorApp.Shared.Dtos.Admin;
 using SensorApp.Shared.Enums;
-using SensorApp.Tests.IntegrationTests.ApiEndpoints.AuthEndpoints;
 using SensorApp.Tests.IntegrationTests.ApiEndpoints.Helpers;
 using System.Net;
 using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.AdminEndpoints;
 
+/// <summary>
+/// Integration tests for the admin endpoint responsible for deleting users.
+/// </summary>
 public class AdminDeleteUsersEndpoint : IClassFixture<WebApplicationFactoryForTests>
 {
     private readonly HttpClient _client;

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminGetUsersEndpoint.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminGetUsersEndpoint.cs
@@ -6,12 +6,22 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.AdminEndpoints;
 
-public class AdminGetUsersEndpoint(WebApplicationFactoryForTests factory) : IClassFixture<WebApplicationFactoryForTests>
+
+/// <summary>
+/// Integration tests for the admin endpoint responsible for retrieving all users/ getting them by Id
+/// </summary>
+public class AdminGetUsersEndpoint : IClassFixture<WebApplicationFactoryForTests>
 {
-    private readonly HttpClient _client = factory.CreateClient();
-    private readonly TokenProvider _tokenProvider = new(factory.CreateClient());
+    private readonly HttpClient _client;
+    private readonly TokenProvider _tokenProvider;
 
     private const string _adminEmail = "admin@sensor.com";
+
+    public AdminGetUsersEndpoint(WebApplicationFactoryForTests factory)
+    {
+        _client = factory.CreateClient();
+        _tokenProvider = new TokenProvider(factory.CreateClient());
+    }
 
 
     [Fact]

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminUpdateUsersEndpoint.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AdminEndpoints/AdminUpdateUsersEndpoint.cs
@@ -8,11 +8,20 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.AdminEndpoints;
 
-public class AdminUpdateUserEndpointTests(WebApplicationFactoryForTests factory) : IClassFixture<WebApplicationFactoryForTests>
+/// <summary>
+/// Integration tests for the admin endpoint responsible for updating user information.
+/// </summary>
+public class AdminUpdateUserEndpointTests : IClassFixture<WebApplicationFactoryForTests>
 {
-    private readonly HttpClient _client = factory.CreateClient();
-    private readonly TokenProvider _tokenProvider = new(factory.CreateClient());
-    private string _adminEmail = "admin@sensor.com";
+    private readonly HttpClient _client;
+    private readonly TokenProvider _tokenProvider;
+    private readonly string _adminEmail = "admin@sensor.com";
+
+    public AdminUpdateUserEndpointTests(WebApplicationFactoryForTests factory)
+    {
+        _client = factory.CreateClient();
+        _tokenProvider = new TokenProvider(factory.CreateClient());
+    }
 
     [Fact]
     public async Task Admin_Can_Update_Another_User()

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AuthEndpoints/AuthEndpointsTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/AuthEndpoints/AuthEndpointsTests.cs
@@ -9,11 +9,22 @@ namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.AuthEndpoints;
 
 /// <summary>
 /// Integration tests for the /login authentication endpoint.
-/// These tests verify the behavior by making real HTTP requests against the running API in-memory
+/// These tests verify the behavior by making real HTTP requests against the running API in-memory.
 /// </summary>
-public class AuthEndpointTests(WebApplicationFactoryForTests factory) : IClassFixture<WebApplicationFactoryForTests>
+public class AuthEndpointTests : IClassFixture<WebApplicationFactoryForTests>
 {
-    private readonly HttpClient _client = factory.CreateClient();
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthEndpointTests"/> class.
+    /// Sets up the HTTP client for testing authentication endpoints.
+    /// </summary>
+    /// <param name="factory">A factory for creating a configured web application client instance.</param>
+    public AuthEndpointTests(WebApplicationFactoryForTests factory)
+    {
+        _client = factory.CreateClient();
+    }
+
 
     [Fact]
     public async Task HappyPath_UserLogin_WithValidCredentials_SystemReturnsToken()

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Helpers/TestHelpers.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/Helpers/TestHelpers.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.Helpers;
 
-internal class TestHelpers
+public class TestHelpers
 {
     /// <summary>
     /// Creates an authorized HTTP request by attaching a Bearer token and optional JSON content.

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/MeasurementEndpoints/MeasurementEndpointTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/MeasurementEndpoints/MeasurementEndpointTests.cs
@@ -6,6 +6,9 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.MeasurementEndpoints;
 
+/// <summary>
+/// Integration tests for the /measurements API endpoint.
+/// </summary>
 public class MeasurementEndpointTests : IClassFixture<WebApplicationFactoryForTests>
 {
     private readonly HttpClient _client;

--- a/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/MeasurementEndpoints/SensorMeasurandEndpointTests.cs
+++ b/SensorApp/SensorApp.Tests/IntegrationTests/ApiEndpoints/MeasurementEndpoints/SensorMeasurandEndpointTests.cs
@@ -6,6 +6,10 @@ using System.Net.Http.Json;
 
 namespace SensorApp.Tests.IntegrationTests.ApiEndpoints.MeasurementEndpoints;
 
+/// <summary>
+/// Integration tests for the /sensors/{sensorId}/measurands API endpoint.
+/// Verifies that an authenticated admin user can successfully retrieve the list of measurands associated with a sensor.
+/// </summary>
 public class SensorMeasurandEndpointTests: IClassFixture<WebApplicationFactoryForTests>
 {
     private readonly HttpClient _client;

--- a/SensorApp/SensorApp.Tests/UnitTests/Factory/EnvironmentalMenuFactoryTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Factory/EnvironmentalMenuFactoryTests.cs
@@ -2,6 +2,11 @@
 using SensorApp.Shared.Factories;
 
 namespace SensorApp.Tests.UnitTests.Factory;
+
+/// <summary>
+/// Unit tests for the <see cref="EnvironmentalMenuFactory"/> class.
+/// Verifies that the Environmental Scientist menu factory generates the expected menu items.
+/// </summary>
 public class EnvironmentalMenuFactoryTests
 {
     [Fact]

--- a/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
+++ b/SensorApp/SensorApp.Tests/UnitTests/Factory/OperationsMenuFactoryTests.cs
@@ -2,6 +2,11 @@
 using SensorApp.Shared.Factories;
 
 namespace SensorApp.Tests.UnitTests.Factory;
+
+/// <summary>
+/// Unit tests for the <see cref="OperationsMenuFactory"/> class.
+/// Verifies that the Operations Manager menu factory generates the expected menu items.
+/// </summary>
 public class OperationsMenuFactoryTests
 {
     [Fact]


### PR DESCRIPTION
This PR attempts to add the missing methods in the documentation created by doxygen by not using primary constructors in some of the classes in the codebase that were using it and adding comments on the top level of classes

In Addition, a small change to the documentation.yml pipeline as an attempt to extract the subclasses that we are missing